### PR TITLE
Feature/#26 sort by folder child count

### DIFF
--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -15,6 +15,9 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
      */
     fun findByNameContaining(name: String, pageable: Pageable): Page<MediaFolder>
 
+    /**
+     * Returns all media folders by the count of their children files.
+     */
     @Query(
         value = "select f from MediaFolder f join f.files fi group by f Order By fi.size asc",
         countQuery = "select count(f) from MediaFolder f"
@@ -26,4 +29,19 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
         countQuery = "select count(f) from MediaFolder f"
     )
     fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<MediaFolder>
+
+    /**
+     * Query is the same as the regular one with an added WHERE clause that returns only the folders containing the query.
+     */
+    @Query(
+        value = "select f from MediaFolder f join f.files fi where UPPER(f.name) like CONCAT('%',UPPER(:name),'%') group by f Order By fi.size asc",
+        countQuery = "select count(f) from MediaFolder f"
+    )
+    fun findByNameContainingAndFileCountAsc(name: String, pageable: Pageable): Page<MediaFolder>
+
+    @Query(
+        value = "select f from MediaFolder f join f.files fi where UPPER(f.name) like CONCAT('%',UPPER(:name),'%') group by f Order By fi.size desc",
+        countQuery = "select count(f) from MediaFolder f"
+    )
+    fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<MediaFolder>
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -4,10 +4,26 @@ import com.guillermonegrete.gallery.data.MediaFolder
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
 
     fun findByName(name: String): MediaFolder?
 
+    /**
+     * Returns folders whose name contains the given string
+     */
     fun findByNameContaining(name: String, pageable: Pageable): Page<MediaFolder>
+
+    @Query(
+        value = "select f from MediaFolder f join f.files fi group by f Order By fi.size asc",
+        countQuery = "select count(f) from MediaFolder f"
+    )
+    fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<MediaFolder>
+
+    @Query(
+        value = "select f from MediaFolder f join f.files fi group by f Order By fi.size desc",
+        countQuery = "select count(f) from MediaFolder f"
+    )
+    fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<MediaFolder>
 }


### PR DESCRIPTION
Closes #26. Implemented using direct queries. Another solution that possibly is more performant is using a [secondary table](https://stackoverflow.com/a/40170121/10244759).