### PR TITLE
Bugfix/#87 repeated items

### DIFF
--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
@@ -118,11 +118,12 @@ class FoldersController(
         val sort = pageable.sort.firstOrNull()
         return if(sort?.property == "count") {
             val newPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
-            if(sort.isDescending)
+            val result = if(sort.isDescending)
                 mediaFolderRepo.findByNameContainingAndFileCountDesc(query, newPageable) else mediaFolderRepo.findByNameContainingAndFileCountAsc(query, newPageable)
+            result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
         } else {
-            mediaFolderRepo.findByNameContaining(query, pageable)
-        }.map { Folder(it.name, it.getCover(), it.files.size, it.id)  }
+            mediaFolderRepo.findByNameContaining(query, pageable).map { Folder(it.name, it.getCover(), it.files.size, it.id)  }
+        }
     }
 
     fun MediaFolder.toDto(fileName: String): Folder {

--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
@@ -39,10 +39,10 @@ class FoldersController(
         val folders = if(query == null) getFolderPage(pageable) else getFolderPage(query, pageable)
 
         val finalFolders = folders.content.map { folder ->
-            val firstFilename = folder.coverFile?.filename ?: folder.files.firstOrNull()?.filename ?: ""
+            val firstFilename = folder.coverUrl
             val coverUrl = "http://$ipAddress/images/${folder.name}/$firstFilename"
 
-            Folder(folder.name, coverUrl, folder.files.size, folder.id)
+            folder.copy(coverUrl = coverUrl)
         }
 
         return PagedFolderResponse(getFolderName(), SimplePage(finalFolders, folders.totalPages, folders.totalElements.toInt()))
@@ -98,22 +98,23 @@ class FoldersController(
     /**
      * Returns the page of folders by the given pageable.
      */
-    private fun getFolderPage(pageable: Pageable): Page<MediaFolder> {
+    private fun getFolderPage(pageable: Pageable): Page<Folder> {
         val sort = pageable.sort.firstOrNull()
         return if(sort?.property == "count") {
             // Sorting by child count is a special case because it's not an entity column
             // Created pageable without the "count" sort field, otherwise it will produce an error
             val newPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
-            if(sort.isDescending) mediaFolderRepo.findAllMediaFolderByFileCountDesc(newPageable)  else mediaFolderRepo.findAllMediaFolderByFileCountAsc(newPageable)
+            val result = if(sort.isDescending) mediaFolderRepo.findAllMediaFolderByFileCountDesc(newPageable) else mediaFolderRepo.findAllMediaFolderByFileCountAsc(newPageable)
+            result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
         } else {
-            mediaFolderRepo.findAll(pageable)
+            mediaFolderRepo.findAll(pageable).map { Folder(it.name, it.getCover(), it.files.size, it.id) }
         }
     }
 
     /**
      * Returns the page of folders by the given pageable that contains the query in the name.
      */
-    fun getFolderPage(query: String, pageable: Pageable): Page<MediaFolder> {
+    fun getFolderPage(query: String, pageable: Pageable): Page<Folder> {
         val sort = pageable.sort.firstOrNull()
         return if(sort?.property == "count") {
             val newPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
@@ -121,7 +122,7 @@ class FoldersController(
                 mediaFolderRepo.findByNameContainingAndFileCountDesc(query, newPageable) else mediaFolderRepo.findByNameContainingAndFileCountAsc(query, newPageable)
         } else {
             mediaFolderRepo.findByNameContaining(query, pageable)
-        }
+        }.map { Folder(it.name, it.getCover(), it.files.size, it.id)  }
     }
 
     fun MediaFolder.toDto(fileName: String): Folder {
@@ -138,4 +139,6 @@ class FoldersController(
             paths.last()
         }
     }
+
+    private fun MediaFolder.getCover() = coverFile?.filename ?: files.firstOrNull()?.filename ?: ""
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -18,17 +18,21 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     /**
      * Returns all media folders by the count of their children files.
      */
-    @Query(value = "SELECT * FROM media_folder " +
-            "group by media_folder.id order by (SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) asc, media_folder.id",
+    @Query(value = "SELECT name, " +
+            "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
+            "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder " +
+            "group by media_folder.id order by count asc, media_folder.id",
         countQuery = "SELECT count(*) FROM media_folder",
         nativeQuery = true)
-    fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<MediaFolder>
+    fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<FolderDto>
 
-    @Query(value = "SELECT * FROM media_folder " +
-            "group by media_folder.id order by (SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) desc, media_folder.id",
+    @Query(value = "SELECT name, " +
+            "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
+            "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder " +
+            "group by media_folder.id order by count desc, media_folder.id",
         countQuery = "SELECT count(*) FROM media_folder",
         nativeQuery = true)
-    fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<MediaFolder>
+    fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<FolderDto>
 
     /**
      * Query is the same as the regular one with an added WHERE clause that returns only the folders containing the query.
@@ -44,4 +48,11 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
         countQuery = "select count(f) from MediaFolder f"
     )
     fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<MediaFolder>
+}
+
+interface FolderDto {
+    val name:String
+    val coverUrl: String?
+    val count: Int
+    val id: Long
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -18,18 +18,12 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     /**
      * Returns all media folders by the count of their children files.
      */
-    @Query(value = "SELECT name, " +
-            "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
-            "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder " +
-            "group by media_folder.id order by count asc, media_folder.id",
+    @Query(value = query + folderAscOrder,
         countQuery = "SELECT count(*) FROM media_folder",
         nativeQuery = true)
     fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<FolderDto>
 
-    @Query(value = "SELECT name, " +
-            "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
-            "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder " +
-            "group by media_folder.id order by count desc, media_folder.id",
+    @Query(value = query + folderDescOrder,
         countQuery = "SELECT count(*) FROM media_folder",
         nativeQuery = true)
     fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<FolderDto>
@@ -49,6 +43,14 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     )
     fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<MediaFolder>
 }
+
+private const val query = "SELECT name, " +
+        "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
+        "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder "
+
+private const val folderAscOrder = "group by media_folder.id order by count asc, media_folder.id"
+
+private const val folderDescOrder = "group by media_folder.id order by count desc, media_folder.id"
 
 interface FolderDto {
     val name:String

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -18,16 +18,16 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     /**
      * Returns all media folders by the count of their children files.
      */
-    @Query(
-        value = "select f from MediaFolder f join f.files fi group by f Order By COUNT(fi) asc",
-        countQuery = "select count(f) from MediaFolder f"
-    )
+    @Query(value = "SELECT * FROM media_folder " +
+            "group by media_folder.id order by (SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) asc, media_folder.id",
+        countQuery = "SELECT count(*) FROM media_folder",
+        nativeQuery = true)
     fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<MediaFolder>
 
-    @Query(
-        value = "select f from MediaFolder f join f.files fi group by f Order By COUNT(fi) desc",
-        countQuery = "select count(f) from MediaFolder f"
-    )
+    @Query(value = "SELECT * FROM media_folder " +
+            "group by media_folder.id order by (SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) desc, media_folder.id",
+        countQuery = "SELECT count(*) FROM media_folder",
+        nativeQuery = true)
     fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<MediaFolder>
 
     /**

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -18,13 +18,13 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     /**
      * Returns all media folders by the count of their children files.
      */
-    @Query(value = query + folderAscOrder,
-        countQuery = "SELECT count(*) FROM media_folder",
+    @Query(value = folderDtoSelect + folderAscOrder,
+        countQuery = folderCountQuery,
         nativeQuery = true)
     fun findAllMediaFolderByFileCountAsc(pageable: Pageable): Page<FolderDto>
 
-    @Query(value = query + folderDescOrder,
-        countQuery = "SELECT count(*) FROM media_folder",
+    @Query(value = folderDtoSelect + folderDescOrder,
+        countQuery = folderCountQuery,
         nativeQuery = true)
     fun findAllMediaFolderByFileCountDesc(pageable: Pageable): Page<FolderDto>
 
@@ -32,25 +32,31 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
      * Query is the same as the regular one with an added WHERE clause that returns only the folders containing the query.
      */
     @Query(
-        value = "select f from MediaFolder f join f.files fi where UPPER(f.name) like CONCAT('%',UPPER(:name),'%') group by f Order By COUNT(fi) asc",
-        countQuery = "select count(f) from MediaFolder f"
+        value = folderDtoSelect + folderNameContains + folderAscOrder,
+        countQuery = folderCountQuery,
+        nativeQuery = true
     )
-    fun findByNameContainingAndFileCountAsc(name: String, pageable: Pageable): Page<MediaFolder>
+    fun findByNameContainingAndFileCountAsc(name: String, pageable: Pageable): Page<FolderDto>
 
     @Query(
-        value = "select f from MediaFolder f join f.files fi where UPPER(f.name) like CONCAT('%',UPPER(:name),'%') group by f Order By COUNT(fi) desc",
-        countQuery = "select count(f) from MediaFolder f"
+        value = folderDtoSelect + folderNameContains + folderDescOrder ,
+        countQuery = folderCountQuery,
+        nativeQuery = true
     )
-    fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<MediaFolder>
+    fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<FolderDto>
 }
 
-private const val query = "SELECT name, " +
+private const val folderDtoSelect = "SELECT name, " +
         "IFNULL((SELECT filename FROM media_file where media_file.id = cover_file_id), (SELECT filename FROM media_file where media_file.folder_id = media_folder.id LIMIT 1)) as coverUrl, " + //
         "(SELECT count(folder_id) FROM media_file where folder_id = media_folder.id) as count, id FROM media_folder "
 
 private const val folderAscOrder = "group by media_folder.id order by count asc, media_folder.id"
 
 private const val folderDescOrder = "group by media_folder.id order by count desc, media_folder.id"
+
+private const val folderNameContains = "where UPPER(media_folder.name) like CONCAT('%',UPPER(:name),'%') "
+
+private const val folderCountQuery = "SELECT count(*) FROM media_folder"
 
 interface FolderDto {
     val name:String


### PR DESCRIPTION
Closes #87.

Also, improved the performance of the folder list request when sorting by count. This was done by getting the folder count directly from the query instead of using the list of the entity object.