### PR TITLE
Feature/#55 folder tags

### DIFF
--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
@@ -7,6 +7,7 @@ import com.guillermonegrete.gallery.data.PagedFolderResponse
 import com.guillermonegrete.gallery.data.SimplePage
 import com.guillermonegrete.gallery.data.files.FileMapper
 import com.guillermonegrete.gallery.data.files.dto.FileDTO
+import com.guillermonegrete.gallery.data.toDto
 import com.guillermonegrete.gallery.repository.MediaFileRepository
 import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import org.springframework.beans.factory.annotation.Autowired
@@ -91,7 +92,7 @@ class FoldersController(
 
         folder.coverFile = file
 
-        val savedFolder = mediaFolderRepo.save(folder).toDto(file.filename)
+        val savedFolder = mediaFolderRepo.save(folder).toDto(file.filename, ipAddress)
         return ResponseEntity(savedFolder, HttpStatus.OK)
     }
 
@@ -107,7 +108,7 @@ class FoldersController(
             val result = if(sort.isDescending) mediaFolderRepo.findAllMediaFolderByFileCountDesc(newPageable) else mediaFolderRepo.findAllMediaFolderByFileCountAsc(newPageable)
             result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
         } else {
-            mediaFolderRepo.findAll(pageable).map { Folder(it.name, it.getCover(), it.files.size, it.id) }
+            mediaFolderRepo.findAll(pageable).map { it.toDto() }
         }
     }
 
@@ -122,13 +123,8 @@ class FoldersController(
                 mediaFolderRepo.findByNameContainingAndFileCountDesc(query, newPageable) else mediaFolderRepo.findByNameContainingAndFileCountAsc(query, newPageable)
             result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
         } else {
-            mediaFolderRepo.findByNameContaining(query, pageable).map { Folder(it.name, it.getCover(), it.files.size, it.id)  }
+            mediaFolderRepo.findByNameContaining(query, pageable).map { it.toDto() }
         }
-    }
-
-    fun MediaFolder.toDto(fileName: String): Folder {
-        val coverUrl = "http://$ipAddress/images/$name/$fileName"
-        return Folder(name, coverUrl, files.size, id)
     }
 
     fun getFolderName(): String {

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
@@ -11,3 +11,10 @@ data class PagedFolderResponse(
         val name: String,
         val page: SimplePage<Folder>
 )
+
+fun MediaFolder.toDto(fileName: String, ipAddress: String): Folder {
+    val coverUrl = "http://$ipAddress/images/$name/$fileName"
+    return Folder(name, coverUrl, files.size, id)
+}
+
+fun MediaFolder.toDto() = Folder(name, coverFile?.filename ?: files.firstOrNull()?.filename ?: "", files.size, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFile.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFile.kt
@@ -1,7 +1,7 @@
 package com.guillermonegrete.gallery.data
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.guillermonegrete.gallery.tags.data.TagEntity
+import com.guillermonegrete.gallery.tags.data.TagFile
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorColumn
 import jakarta.persistence.DiscriminatorType
@@ -37,8 +37,8 @@ open class MediaFile(
     open val creationDate: Instant = Instant.now(),
     @Column(name = "last_modified", nullable = false)
     open val lastModified: Instant = Instant.now(),
-    @ManyToMany(targetEntity = TagEntity::class, mappedBy = "files")
-    open val tags: MutableSet<TagEntity> = mutableSetOf(),
+    @ManyToMany(targetEntity = TagFile::class, mappedBy = "files")
+    open val tags: MutableSet<TagFile> = mutableSetOf(),
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "folder_id")
     @JsonIgnoreProperties("files")
@@ -53,7 +53,7 @@ open class MediaFile(
     /**
      * Returns true if the tag wasn't already applied, false otherwise.
      */
-    fun addTag(tag: TagEntity): Boolean {
+    fun addTag(tag: TagFile): Boolean {
         tag.files.add(this)
         return tags.add(tag)
     }

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
@@ -39,4 +39,10 @@ data class MediaFolder(
         tag.folders.add(this)
         return tags.add(tag)
     }
+
+    fun removeTag(tagId: Long) {
+        val tag = tags.firstOrNull { it.id == tagId } ?: return
+        tags.remove(tag)
+        tag.folders.remove(this)
+    }
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
@@ -1,5 +1,7 @@
 package com.guillermonegrete.gallery.data
 
+import com.guillermonegrete.gallery.tags.data.TagFile
+import com.guillermonegrete.gallery.tags.data.TagFolder
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -8,6 +10,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToMany
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 
@@ -20,6 +23,8 @@ data class MediaFolder(
     @OneToOne
     @JoinColumn(name = "cover_file_id")
     var coverFile: MediaFile? = null,
+    @ManyToMany(targetEntity = TagFolder::class, mappedBy = "folders")
+    val tags: MutableSet<TagFolder> = mutableSetOf(),
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     val id: Long = 0,
 ) {

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/MediaFolder.kt
@@ -31,4 +31,12 @@ data class MediaFolder(
     override fun toString(): String {
         return "{name: $name, id: $id}"
     }
+
+    /**
+     * Returns true if the tag wasn't already applied, false otherwise.
+     */
+    fun addTag(tag: TagFolder): Boolean {
+        tag.folders.add(this)
+        return tags.add(tag)
+    }
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFileRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFileRepository.kt
@@ -17,14 +17,37 @@ interface MediaFileRepository : JpaRepository<MediaFile, Long>{
     /**
      * Gets a page of all the files that have all the specified tags applied.
      */
-    fun findFilesByTagsIds(tagIds: List<Long>, pageable: Pageable): Page<MediaFile>
-       = findFilesByTagsIds(tagIds, tagIds.size, pageable)
+    fun findFilesByFileTagsIds(tagIds: List<Long>, pageable: Pageable): Page<MediaFile>
+       = findFilesByFileTagsIds(tagIds, tagIds.size, pageable)
+
+    fun findFilesByFolderTagsIds(tagIds: List<Long>, pageable: Pageable): Page<MediaFile>
+            = findFilesByFolderTagsIds(tagIds, tagIds.size, pageable)
+
+    fun findFilesByTagsIds(tagIds: List<Long>, folderTagIds: List<Long>, pageable: Pageable): Page<MediaFile>
+            = findFilesByTagsIds(tagIds, folderTagIds, tagIds.size + folderTagIds.size, pageable)
 
     @Query("""select file from MediaFile file 
         where :numberOfTags = (select count(tag.id) from MediaFile file2 
                                 inner join file2.tags tag 
                                 where file2.id = file.id and tag.id in (:tagIds))""")
-    fun findFilesByTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFile>
+    fun findFilesByFileTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFile>
+
+    @Query("""select file from MediaFile file 
+        where :numberOfTags = (select count(tag.id) from MediaFolder folder 
+                                inner join folder.tags tag 
+                                where file.folder.id = folder.id and tag.id in (:tagIds))
+                                """)
+    fun findFilesByFolderTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFile>
+
+    @Query("""select file from MediaFile file 
+        where :numberOfTags = (select count(tag.id) from MediaFile file2 
+                                inner join file2.tags tag 
+                                where file2.id = file.id and tag.id in (:tagIds)) +
+                                (select count(tag.id) from MediaFolder folder 
+                                inner join folder.tags tag 
+                                where file.folder.id = folder.id and tag.id in (:folderTagIds))
+                                """)
+    fun findFilesByTagsIds(tagIds: List<Long>, folderTagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFile>
 
     /**
      * Gets a page of all the files that have all the specified tags applied for the specified folder.

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -47,6 +47,17 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
     fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<FolderDto>
 
     fun findByIdIn(ids: List<Long>): List<MediaFolder>
+
+    fun findFoldersByTagId(tagId: Long, pageable: Pageable): Page<MediaFolder>
+
+    fun findFoldersByTagIds(tagIds: List<Long>, pageable: Pageable)
+        = findFilesByTagsIds(tagIds, tagIds.size, pageable)
+
+    @Query("""select folder from MediaFolder folder 
+        where :numberOfTags = (select count(tag.id) from MediaFolder folder2 
+                                inner join folder2.tags tag 
+                                where folder2.id = folder.id and tag.id in (:tagIds))""")
+    fun findFilesByTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFolder>
 }
 
 private const val folderDtoSelect = "SELECT name, " +

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.gallery.repository
 
-import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.MediaFolder
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -48,16 +47,42 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
 
     fun findByIdIn(ids: List<Long>): List<MediaFolder>
 
-    fun findFoldersByTagId(tagId: Long, pageable: Pageable): Page<MediaFolder>
+    fun findFoldersByTagsId(tagId: Long, pageable: Pageable): Page<MediaFolder>
 
     fun findFoldersByTagIds(tagIds: List<Long>, pageable: Pageable)
-        = findFilesByTagsIds(tagIds, tagIds.size, pageable)
+        = findFoldersByTagsIds(tagIds, tagIds.size, pageable)
 
     @Query("""select folder from MediaFolder folder 
         where :numberOfTags = (select count(tag.id) from MediaFolder folder2 
                                 inner join folder2.tags tag 
                                 where folder2.id = folder.id and tag.id in (:tagIds))""")
-    fun findFilesByTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFolder>
+    fun findFoldersByTagsIds(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<MediaFolder>
+
+    @Query("""select folder from MediaFolder folder 
+        where :numberOfTags = (select count(tag.id) from MediaFolder folder2 
+                                inner join folder2.tags tag 
+                                where folder2.id = folder.id and tag.id in (:tagIds)) and UPPER(folder.name) like CONCAT('%',UPPER(:name),'%')""")
+    fun findFoldersByTagsIdsAndContaining(tagIds: List<Long>, numberOfTags: Int, name: String, pageable: Pageable): Page<MediaFolder>
+
+    @Query(value = folderDtoSelect + folderContainsTags + folderAscOrder,
+        countQuery = folderCountQuery,
+        nativeQuery = true)
+    fun findFoldersByFileCountAndTagsAsc(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<FolderDto>
+
+    @Query(value = folderDtoSelect + folderContainsTags + folderDescOrder,
+        countQuery = folderCountQuery,
+        nativeQuery = true)
+    fun findFoldersByFileCountAndTagsDesc(tagIds: List<Long>, numberOfTags: Int, pageable: Pageable): Page<FolderDto>
+
+    @Query(value = folderDtoSelect + folderContainsTags + folderNameContainsAnd + folderAscOrder,
+        countQuery = folderCountQuery,
+        nativeQuery = true)
+    fun findFoldersByFileCountAndTagsAndContainingAsc(tagIds: List<Long>, numberOfTags: Int, name: String, pageable: Pageable): Page<FolderDto>
+
+    @Query(value = folderDtoSelect + folderContainsTags + folderNameContainsAnd + folderDescOrder,
+        countQuery = folderCountQuery,
+        nativeQuery = true)
+    fun findFoldersByFileCountAndTagsAndContainingDesc(tagIds: List<Long>, numberOfTags: Int, name: String, pageable: Pageable): Page<FolderDto>
 }
 
 private const val folderDtoSelect = "SELECT name, " +
@@ -69,6 +94,13 @@ private const val folderAscOrder = "group by media_folder.id order by count asc,
 private const val folderDescOrder = "group by media_folder.id order by count desc, media_folder.id"
 
 private const val folderNameContains = "where UPPER(media_folder.name) like CONCAT('%',UPPER(:name),'%') "
+
+private const val folderNameContainsAnd = "AND UPPER(media_folder.name) like CONCAT('%',UPPER(:name),'%') "
+
+private const val folderContainsTags = """
+    where :numberOfTags = (select count(tag_entity.id) from tag_entity
+    join folder_tags ON tag_entity.id = folder_tags.tag_id
+    where media_folder.id = folder_tags.folder_id and folder_tags.tag_id in (:tagIds)) """
 
 private const val folderCountQuery = "SELECT count(*) FROM media_folder"
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/repository/MediaFolderRepository.kt
@@ -1,5 +1,6 @@
 package com.guillermonegrete.gallery.repository
 
+import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.MediaFolder
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -44,6 +45,8 @@ interface MediaFolderRepository: JpaRepository<MediaFolder, Long>{
         nativeQuery = true
     )
     fun findByNameContainingAndFileCountDesc(name: String, pageable: Pageable): Page<FolderDto>
+
+    fun findByIdIn(ids: List<Long>): List<MediaFolder>
 }
 
 private const val folderDtoSelect = "SELECT name, " +

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -11,6 +11,7 @@ import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.tags.data.TagDto
 import com.guillermonegrete.gallery.tags.data.TagEntity
 import com.guillermonegrete.gallery.tags.data.TagFile
+import com.guillermonegrete.gallery.tags.data.TagFileDto
 import com.guillermonegrete.gallery.tags.data.TagFolder
 import com.guillermonegrete.gallery.tags.data.TagRequest
 import com.guillermonegrete.gallery.tags.data.toDto
@@ -46,7 +47,7 @@ class TagsController(
             when(it) {
                 is TagFile -> it.toDto()
                 is TagFolder -> it.toDto()
-                else -> TagDto("", 0)
+                else -> TagFileDto("", 0)
             }
         }
         return if (tagsDto.isEmpty()) ResponseEntity(HttpStatus.NO_CONTENT) else ResponseEntity(tagsDto, HttpStatus.OK)
@@ -138,6 +139,18 @@ class TagsController(
     }
 
     //region Folders
+
+    @GetMapping("/tags/folders")
+    fun getAllFolderTags(): ResponseEntity<Set<TagDto>> {
+        val tags = folderTagsRepo.getFolderTags()
+        return if (tags.isEmpty()) ResponseEntity(HttpStatus.NO_CONTENT) else ResponseEntity(tags, HttpStatus.OK)
+    }
+
+    @GetMapping("/tags/folders/{id}")
+    fun getFolderTags(@PathVariable id: Long): ResponseEntity<Set<TagDto>> {
+        val folderTags = folderTagsRepo.getFolderTags(id)
+        return ResponseEntity(folderTags, HttpStatus.OK)
+    }
 
     @PostMapping("/folders/tags/add")
     fun createFolderTag(@RequestParam name: String): ResponseEntity<Any> {
@@ -265,8 +278,9 @@ class TagsController(
 
     @GetMapping("folders/{id}/tags")
     fun getTagsByFolder(@PathVariable id: Long): ResponseEntity<Set<TagDto>> {
-        val tagsDto = tagRepo.getTagsWithFilesByFolder(id)
-        return ResponseEntity(tagsDto, HttpStatus.OK)
+        val fileTags = fileTagsRepo.getTagsWithFilesByFolder(id)
+        val folderTags = folderTagsRepo.getFolderTags(id)
+        return ResponseEntity(fileTags + folderTags, HttpStatus.OK)
     }
 
     @GetMapping("folders/{folderId}/tags/{tagId}")

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -47,6 +47,7 @@ class TagsController(
             when(it) {
                 is TagFile -> it.toDto()
                 is TagFolder -> it.toDto()
+                else -> TagDto("", 0)
             }
         }
         return if (tagsDto.isEmpty()) ResponseEntity(HttpStatus.NO_CONTENT) else ResponseEntity(tagsDto, HttpStatus.OK)
@@ -137,7 +138,8 @@ class TagsController(
         return ResponseEntity(tags, HttpStatus.OK)
     }
 
-    //region MyRegionName
+    //region Folders
+
     @PostMapping("/folders/tags/add")
     fun createFolderTag(@RequestParam name: String): ResponseEntity<Any> {
         if (name.isBlank()) return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Tag can't be blank")
@@ -161,7 +163,7 @@ class TagsController(
 
         if(tagId != 0L){
             val savedTag = folderTagsRepo.findById(tagId)
-                .orElseThrow { Exception("Tag with id $tagId not found") }
+                .orElseThrow { Exception("Folder tag with id $tagId not found") }
             folder.addTag(savedTag)
             folderRepo.save(folder)
             return ResponseEntity(savedTag, HttpStatus.OK)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -172,7 +172,7 @@ class TagsController(
         return ResponseEntity(folderTags, HttpStatus.OK)
     }
 
-    @PostMapping("/folders/tags/add")
+    @PostMapping("/tags/folders/add")
     fun createFolderTag(@RequestParam name: String): ResponseEntity<Any> {
         if (name.isBlank()) return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Tag can't be blank")
 
@@ -203,7 +203,7 @@ class TagsController(
 
         val completeTag = folderTagsRepo.findByName(tag.name) ?: TagFolder(tag.name, id = tag.id)
         folder.addTag(completeTag)
-        tagRepo.save(completeTag)
+        folderTagsRepo.save(completeTag)
         return ResponseEntity(completeTag, HttpStatus.OK)
     }
 
@@ -354,5 +354,8 @@ class TagsController(
         return inetAddress.hostAddress
     }
 
-    data class FilterTagsRequest(val fileTagIds: List<Long>, val folderTagIds: List<Long>)
+    data class FilterTagsRequest(
+        val fileTagIds: List<Long> = emptyList(),
+        val folderTagIds: List<Long> = emptyList()
+    )
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -84,7 +84,7 @@ class TagsController(
 
             val completeTag = fileTagsRepo.findByName(tag.name) ?: TagFile(tag.name, id = tag.id)
             file.addTag(completeTag)
-            tagRepo.save(completeTag)
+            fileTagsRepo.save(completeTag)
         }.orElseThrow { Exception("File with id $id not found") }
         return ResponseEntity(newTag, HttpStatus.OK)
     }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -16,6 +16,7 @@ import com.guillermonegrete.gallery.tags.data.TagRequest
 import com.guillermonegrete.gallery.tags.data.toDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
@@ -174,18 +175,48 @@ class TagsController(
     }
 
     @PostMapping("tags/folders")
-    fun getFoldersByTags(@RequestBody ids: List<Long>, pageable: Pageable): ResponseEntity<SimplePage<Folder>>{
+    fun getFoldersByTags(@RequestBody ids: List<Long>, @RequestParam(required = false) query: String?, pageable: Pageable): ResponseEntity<SimplePage<Folder>>{
         if(ids.isEmpty()) throw Exception("The tag list is empty")
 
         val finalIds = ids.filter { tagRepo.existsById(it) }
         if (finalIds.isEmpty()) return ResponseEntity(SimplePage(), HttpStatus.OK)
 
-        val foldersPage = if (finalIds.size == 1)
-            folderRepo.findFoldersByTagId(finalIds.first(), pageable) else folderRepo.findFoldersByTagIds(finalIds, pageable)
+        val sort = pageable.sort.firstOrNull()
+        val foldersPage = if (query != null) {
+            if(sort?.property == "count") {
+                // Sorting by child count is a special case because it's not an entity column
+                // Created pageable without the "count" sort field, otherwise it will produce an error
+                val newPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
+                val result = if(sort.isDescending)
+                    folderRepo.findFoldersByFileCountAndTagsAndContainingDesc(finalIds, finalIds.size, query, newPageable)
+                else
+                    folderRepo.findFoldersByFileCountAndTagsAndContainingAsc(finalIds, finalIds.size, query, newPageable)
+                result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
+            } else {
+                val folders = folderRepo.findFoldersByTagsIdsAndContaining(finalIds, finalIds.size, query, pageable)
+                folders.map { it.toDto() }
+            }
+        } else {
+            if (sort?.property == "count") {
+                // Sorting by child count is a special case because it's not an entity column
+                // Created pageable without the "count" sort field, otherwise it will produce an error
+                val newPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
+                val result = if (sort.isDescending)
+                    folderRepo.findFoldersByFileCountAndTagsDesc(finalIds, finalIds.size, newPageable)
+                else
+                    folderRepo.findFoldersByFileCountAndTagsAsc(finalIds, finalIds.size, newPageable)
+                result.map { Folder(it.name, it.coverUrl ?: "", it.count, it.id) }
+            } else {
+                val folders = if (finalIds.size == 1)
+                    folderRepo.findFoldersByTagsId(finalIds.first(), pageable) else folderRepo.findFoldersByTagIds(
+                    finalIds,
+                    pageable
+                )
+                folders.map { it.toDto() }
+            }
+        }
 
-        val finalFiles = foldersPage.content.map { it.toDto() }
-
-        val page  = SimplePage(finalFiles, foldersPage.totalPages, foldersPage.totalElements.toInt())
+        val page  = SimplePage(foldersPage.content, foldersPage.totalPages, foldersPage.totalElements.toInt())
         return ResponseEntity(page, HttpStatus.OK)
     }
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsController.kt
@@ -243,6 +243,24 @@ class TagsController(
         return ResponseEntity(tags, HttpStatus.OK)
     }
 
+    @DeleteMapping("tags/folders/{id}")
+    fun deleteFolderTag(@PathVariable("id") id: Long): ResponseEntity<HttpStatus> {
+        folderTagsRepo.deleteById(id)
+        return ResponseEntity(HttpStatus.NO_CONTENT)
+    }
+
+    @DeleteMapping("/folders/{folderId}/tags/{tagId}")
+    fun deleteTagFromFolder(
+        @PathVariable folderId: Long,
+        @PathVariable tagId: Long
+    ): ResponseEntity<HttpStatus> {
+        val folder = folderRepo.findById(folderId)
+            .orElseThrow { RuntimeException("Folder not found with id = $folderId") }
+        folder.removeTag(tagId)
+        folderRepo.save(folder)
+        return ResponseEntity(HttpStatus.NO_CONTENT)
+    }
+
     //endregion
 
     @GetMapping("folders/{id}/tags")
@@ -280,12 +298,12 @@ class TagsController(
     }
 
     @DeleteMapping("/files/{fileId}/tags/{tagId}")
-    fun deleteTagFromTutorial(
+    fun deleteTagFromFiles(
         @PathVariable fileId: Long,
         @PathVariable tagId: Long
     ): ResponseEntity<HttpStatus> {
         val file = filesRepo.findById(fileId)
-            .orElseThrow { RuntimeException("Not found Tutorial with id = $fileId") }
+            .orElseThrow { RuntimeException("File not found with id = $fileId") }
         file.removeTag(tagId)
         filesRepo.save(file)
         return ResponseEntity(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -1,9 +1,10 @@
 package com.guillermonegrete.gallery.tags
 
-import com.guillermonegrete.gallery.tags.data.TagDto
 import com.guillermonegrete.gallery.tags.data.TagEntity
 import com.guillermonegrete.gallery.tags.data.TagFile
+import com.guillermonegrete.gallery.tags.data.TagFileDto
 import com.guillermonegrete.gallery.tags.data.TagFolder
+import com.guillermonegrete.gallery.tags.data.TagFolderDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -12,10 +13,6 @@ interface TagsRepository: JpaRepository<TagEntity, Long>{
     fun findByName(name: String): TagEntity?
 
     fun findByIdIn(ids: List<Long>): List<TagEntity>
-
-    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +
-            "JOIN t.files AS f WHERE :folderId = f.folder.id GROUP BY t.id")
-    fun getTagsWithFilesByFolder(folderId: Long): Set<TagDto>
 }
 
 interface FileTagsRepository: JpaRepository<TagFile, Long>{
@@ -23,6 +20,10 @@ interface FileTagsRepository: JpaRepository<TagFile, Long>{
     fun findByName(name: String): TagFile?
 
     fun findByIdIn(ids: List<Long>): List<TagFile>
+
+    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +
+            "JOIN t.files AS f WHERE :folderId = f.folder.id GROUP BY t.id")
+    fun getTagsWithFilesByFolder(folderId: Long): Set<TagFileDto>
 }
 
 interface FolderTagsRepository: JpaRepository<TagFolder, Long>{
@@ -30,4 +31,11 @@ interface FolderTagsRepository: JpaRepository<TagFolder, Long>{
     fun findByName(name: String): TagFolder?
 
     fun findByIdIn(ids: List<Long>): List<TagFolder>
+
+    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFolderDto(t.name, SIZE(t.folders), t.creationDate, t.id) FROM TagFolder AS t")
+    fun getFolderTags(): Set<TagFolderDto>
+
+    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFolderDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +
+            "JOIN t.folders AS f WHERE :folderId = f.id GROUP BY t.id")
+    fun getFolderTags(folderId: Long): Set<TagFolderDto>
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -2,6 +2,7 @@ package com.guillermonegrete.gallery.tags
 
 import com.guillermonegrete.gallery.tags.data.TagDto
 import com.guillermonegrete.gallery.tags.data.TagEntity
+import com.guillermonegrete.gallery.tags.data.TagFile
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -14,4 +15,11 @@ interface TagsRepository: JpaRepository<TagEntity, Long>{
     @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +
             "JOIN t.files AS f WHERE :folderId = f.folder.id GROUP BY t.id")
     fun getTagsWithFilesByFolder(folderId: Long): Set<TagDto>
+}
+
+interface FileTagsRepository: JpaRepository<TagFile, Long>{
+
+    fun findByName(name: String): TagFile?
+
+    fun findByIdIn(ids: List<Long>): List<TagFile>
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -8,12 +8,7 @@ import com.guillermonegrete.gallery.tags.data.TagFolderDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface TagsRepository: JpaRepository<TagEntity, Long>{
-
-    fun findByName(name: String): TagEntity?
-
-    fun findByIdIn(ids: List<Long>): List<TagEntity>
-}
+interface TagsRepository: JpaRepository<TagEntity, Long>
 
 interface FileTagsRepository: JpaRepository<TagFile, Long>{
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -3,6 +3,7 @@ package com.guillermonegrete.gallery.tags
 import com.guillermonegrete.gallery.tags.data.TagDto
 import com.guillermonegrete.gallery.tags.data.TagEntity
 import com.guillermonegrete.gallery.tags.data.TagFile
+import com.guillermonegrete.gallery.tags.data.TagFolder
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -22,4 +23,11 @@ interface FileTagsRepository: JpaRepository<TagFile, Long>{
     fun findByName(name: String): TagFile?
 
     fun findByIdIn(ids: List<Long>): List<TagFile>
+}
+
+interface FolderTagsRepository: JpaRepository<TagFolder, Long>{
+
+    fun findByName(name: String): TagFolder?
+
+    fun findByIdIn(ids: List<Long>): List<TagFolder>
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
@@ -1,9 +1,15 @@
 package com.guillermonegrete.gallery.tags.data
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-data class TagDto(
+sealed class TagDto(
+    @get:JsonProperty("tag_type")
+    val type: TagType
+)
+
+data class TagFileDto(
     val name: String,
     val count: Long,
     /**
@@ -11,4 +17,19 @@ data class TagDto(
      */
     val creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
     val id: Long = 0,
-)
+): TagDto(TagType.File)
+
+data class TagFolderDto(
+    val name: String,
+    val count: Long,
+    /**
+     * By default, the db saves in seconds, truncate to avoid having different milliseconds
+     */
+    val creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
+    val id: Long = 0,
+): TagDto(TagType.Folder)
+
+enum class TagType{
+    Folder,
+    File,
+}

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
@@ -1,14 +1,18 @@
 package com.guillermonegrete.gallery.tags.data
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "tag_type", visible = true)
 sealed class TagDto(
     @get:JsonProperty("tag_type")
     val type: TagType
 )
 
+@JsonTypeName("File")
 data class TagFileDto(
     val name: String,
     val count: Long,
@@ -19,6 +23,7 @@ data class TagFileDto(
     val id: Long = 0,
 ): TagDto(TagType.File)
 
+@JsonTypeName("Folder")
 data class TagFolderDto(
     val name: String,
     val count: Long,

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
@@ -1,15 +1,14 @@
 package com.guillermonegrete.gallery.tags.data
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.guillermonegrete.gallery.data.MediaFile
 import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.JoinTable
-import jakarta.persistence.ManyToMany
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -17,31 +16,20 @@ import java.time.temporal.ChronoUnit
  * Represent a tag in the database.
  */
 @Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="tag_type",
+    discriminatorType = DiscriminatorType.INTEGER)
 open class TagEntity(
     @Column(nullable = false, unique = true)
     open val name: String = "",
     @Column(name = "creation_date", nullable = false)
     open val creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS), // by default the db saves in seconds, truncate to avoid having different milliseconds
-    /**
-     * A tag can be applied to many files.
-     */
-    @ManyToMany
-    @JoinTable(
-        name = "media_tags",
-        joinColumns = [JoinColumn(name = "tag_id", referencedColumnName = "id")],
-        inverseJoinColumns = [JoinColumn(name = "media_id", referencedColumnName = "id")]
-    )
-    @JsonIgnore
-    open val files: MutableSet<MediaFile> = mutableSetOf(),
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     open val id: Long = 0,
 ){
 
-
     override fun toString(): String {
         return "{id: $id, name: $name, date: $creationDate}"
     }
 }
-
-fun TagEntity.toDto() = TagDto(name, files.size.toLong(), creationDate, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
@@ -19,7 +19,7 @@ import java.time.temporal.ChronoUnit
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name="tag_type",
     discriminatorType = DiscriminatorType.INTEGER)
-open class TagEntity(
+sealed class TagEntity(
     @Column(nullable = false, unique = true)
     open val name: String = "",
     @Column(name = "creation_date", nullable = false)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -19,8 +21,11 @@ import java.time.temporal.ChronoUnit
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name="tag_type",
     discriminatorType = DiscriminatorType.INTEGER)
+@Table(uniqueConstraints=[
+    UniqueConstraint(columnNames = ["name", "tag_type"])
+])
 open class TagEntity(
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     open val name: String = "",
     @Column(name = "creation_date", nullable = false)
     open val creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS), // by default the db saves in seconds, truncate to avoid having different milliseconds

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagEntity.kt
@@ -19,7 +19,7 @@ import java.time.temporal.ChronoUnit
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name="tag_type",
     discriminatorType = DiscriminatorType.INTEGER)
-sealed class TagEntity(
+open class TagEntity(
     @Column(nullable = false, unique = true)
     open val name: String = "",
     @Column(name = "creation_date", nullable = false)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
@@ -1,0 +1,29 @@
+package com.guillermonegrete.gallery.tags.data
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.guillermonegrete.gallery.data.MediaFile
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Entity
+@DiscriminatorValue("1")
+open class TagFile(
+    name: String = "",
+    creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
+    @ManyToMany
+    @JoinTable(
+        name = "media_tags",
+        joinColumns = [JoinColumn(name = "tag_id", referencedColumnName = "id")],
+        inverseJoinColumns = [JoinColumn(name = "media_id", referencedColumnName = "id")]
+    )
+    @JsonIgnore
+    open val files: MutableSet<MediaFile> = mutableSetOf(),
+    id: Long = 0
+): TagEntity(name, creationDate, id)
+
+fun TagFile.toDto() = TagDto(name, files.size.toLong(), creationDate, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
@@ -26,4 +26,4 @@ open class TagFile(
     id: Long = 0
 ): TagEntity(name, creationDate, id)
 
-fun TagFile.toDto() = TagDto(name, files.size.toLong(), creationDate, id)
+fun TagFile.toDto() = TagFileDto(name, files.size.toLong(), creationDate, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
@@ -23,6 +23,7 @@ open class TagFolder(
     )
     @JsonIgnore
     open val folders: MutableSet<MediaFolder> = mutableSetOf(),
-): TagEntity(name, creationDate)
+    id: Long = 0,
+): TagEntity(name, creationDate, id)
 
 fun TagFolder.toDto() = TagDto(name, folders.size.toLong(), creationDate, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
@@ -26,4 +26,4 @@ open class TagFolder(
     id: Long = 0,
 ): TagEntity(name, creationDate, id)
 
-fun TagFolder.toDto() = TagDto(name, folders.size.toLong(), creationDate, id)
+fun TagFolder.toDto() = TagFolderDto(name, folders.size.toLong(), creationDate, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
@@ -13,13 +13,13 @@ import java.time.temporal.ChronoUnit
 @Entity
 @DiscriminatorValue("2")
 open class TagFolder(
-    name: String,
+    name: String = "",
     creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
     @ManyToMany
     @JoinTable(
-        name = "media_tags",
+        name = "folder_tags",
         joinColumns = [JoinColumn(name = "tag_id", referencedColumnName = "id")],
-        inverseJoinColumns = [JoinColumn(name = "media_id", referencedColumnName = "id")]
+        inverseJoinColumns = [JoinColumn(name = "folder_id", referencedColumnName = "id")]
     )
     @JsonIgnore
     open val folders: MutableSet<MediaFolder> = mutableSetOf(),

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFolder.kt
@@ -1,0 +1,28 @@
+package com.guillermonegrete.gallery.tags.data
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.guillermonegrete.gallery.data.MediaFolder
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.ManyToMany
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Entity
+@DiscriminatorValue("2")
+open class TagFolder(
+    name: String,
+    creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
+    @ManyToMany
+    @JoinTable(
+        name = "media_tags",
+        joinColumns = [JoinColumn(name = "tag_id", referencedColumnName = "id")],
+        inverseJoinColumns = [JoinColumn(name = "media_id", referencedColumnName = "id")]
+    )
+    @JsonIgnore
+    open val folders: MutableSet<MediaFolder> = mutableSetOf(),
+): TagEntity(name, creationDate)
+
+fun TagFolder.toDto() = TagDto(name, folders.size.toLong(), creationDate, id)

--- a/src/main/resources/db/migration/V6__tag_types.sql
+++ b/src/main/resources/db/migration/V6__tag_types.sql
@@ -1,3 +1,12 @@
--- Default 1 is one because
+-- Default 1 is one because only file tags exist
 ALTER TABLE tag_entity ADD tag_type integer not null;
 UPDATE tag_entity SET tag_type = 1;
+
+-- Create join
+CREATE TABLE `folder_tags` (
+  `tag_id` bigint NOT NULL,
+  `folder_id` bigint NOT NULL,
+  PRIMARY KEY (`tag_id`,`folder_id`),
+  CONSTRAINT `constr_foldertags_folder_fk` FOREIGN KEY (`folder_id`) REFERENCES `media_folder` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `constr_foldertags_tag_fk` FOREIGN KEY (`tag_id`) REFERENCES `tag_entity` (`id`) ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V6__tag_types.sql
+++ b/src/main/resources/db/migration/V6__tag_types.sql
@@ -2,6 +2,9 @@
 ALTER TABLE tag_entity ADD tag_type integer not null;
 UPDATE tag_entity SET tag_type = 1;
 
+ALTER TABLE tag_entity DROP CONSTRAINT uc_tagentity_name;
+ALTER TABLE tag_entity ADD CONSTRAINT uc_tagentity_name_tagtype UNIQUE (name, tag_type);
+
 -- Create join
 CREATE TABLE `folder_tags` (
   `tag_id` bigint NOT NULL,

--- a/src/main/resources/db/migration/V6__tag_types.sql
+++ b/src/main/resources/db/migration/V6__tag_types.sql
@@ -1,0 +1,3 @@
+-- Default 1 is one because
+ALTER TABLE tag_entity ADD tag_type integer not null;
+UPDATE tag_entity SET tag_type = 1;

--- a/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
@@ -13,6 +13,9 @@ import com.guillermonegrete.gallery.repository.MediaFileRepository
 import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.tags.data.TagDto
 import com.guillermonegrete.gallery.tags.data.TagEntity
+import com.guillermonegrete.gallery.tags.data.TagFile
+import com.guillermonegrete.gallery.tags.data.TagFileDto
+import com.guillermonegrete.gallery.tags.data.TagFolderDto
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
@@ -45,6 +48,8 @@ class TagsControllerTest(
     private lateinit var commandLineRunner: CommandLineRunner
 
     @MockkBean private lateinit var tagsRepository: TagsRepository
+    @MockkBean private lateinit var fileTagsRepository: FileTagsRepository
+    @MockkBean private lateinit var folderTagsRepository: FolderTagsRepository
     @MockkBean private lateinit var mediaFolderRepository: MediaFolderRepository
     @MockkBean private lateinit var mediaFileRepository: MediaFileRepository
     @MockkBean private lateinit var networkConfig: NetworkConfig
@@ -59,7 +64,7 @@ class TagsControllerTest(
     @Test
     fun `Given tags, when get all endpoint called, then return them`(){
 
-        val tags = listOf(TagEntity("my_tag"))
+        val tags = listOf(TagFile("my_tag"))
         every { tagsRepository.findAll() } returns tags
 
         val result = mockMvc.perform(get("/tags"))
@@ -78,8 +83,8 @@ class TagsControllerTest(
     @Test
     fun `Given no tags, when add endpoint called, then create new tag`(){
 
-        val tag = TagEntity("my_tag")
-        every { tagsRepository.save(any()) } returns tag
+        val tag = TagFile("my_tag")
+        every { fileTagsRepository.save(any()) } returns tag
 
         val result = mockMvc.perform(post("/tags/add").param("name", "Cats"))
             .andExpect(status().isOk)
@@ -93,10 +98,10 @@ class TagsControllerTest(
     fun `Given valid file id, when add tag endpoint called, then add tag`(){
 
         every { mediaFileRepository.findById(0) } returns Optional.of(ImageEntity("saved_image.jpg"))
-        val savedTag = TagEntity("my_tag")
-        every { tagsRepository.findByName("my_tag") } returns savedTag
+        val savedTag = TagFile("my_tag")
+        every { fileTagsRepository.findByName("my_tag") } returns savedTag
 
-        every { tagsRepository.save(savedTag) } returns savedTag
+        every { fileTagsRepository.save(savedTag) } returns savedTag
 
         val result = mockMvc.perform(post("/files/{id}/tags", 0)
             .contentType(MediaType.APPLICATION_JSON)
@@ -116,11 +121,11 @@ class TagsControllerTest(
         every { mediaFileRepository.findById(fileId) } returns Optional.of(savedFile)
 
         val files = listOf(
-            TagEntity("tag_1", date),
-            TagEntity("tag_2", date),
-            TagEntity("tag_3", date),
+            TagFile("tag_1", date),
+            TagFile("tag_2", date),
+            TagFile("tag_3", date),
         )
-        every { tagsRepository.findByIdIn(listOf(2,3,4)) } returns files
+        every { fileTagsRepository.findByIdIn(listOf(2,3,4)) } returns files
 
         every { mediaFileRepository.save(any()) } returns savedFile
 
@@ -138,8 +143,8 @@ class TagsControllerTest(
     fun `Given valid tag id, when add tag to files endpoint, then return updated files`(){
         val tagId = 1L
         val date = Instant.now()
-        val savedTag = TagEntity("my_tag", date)
-        every { tagsRepository.findById(tagId) } returns Optional.of(savedTag)
+        val savedTag = TagFile("my_tag", date)
+        every { fileTagsRepository.findById(tagId) } returns Optional.of(savedTag)
 
         val files = listOf(
             MediaFile("file_1", creationDate = date, lastModified = date),
@@ -182,18 +187,21 @@ class TagsControllerTest(
     @Test
     fun `Given valid folder id, when get tags of folder endpoint called, then tags returned`(){
         val folderId = 0L
-        val tag = TagDto("new", 12)
+        val tag = TagFileDto("new", 12)
         val tags = setOf(tag)
-        every { tagsRepository.getTagsWithFilesByFolder(folderId) } returns tags
+        every { fileTagsRepository.getTagsWithFilesByFolder(folderId) } returns tags
+        val folderTag = TagFolderDto("new_folder", 5)
+        every { folderTagsRepository.getFolderTags(folderId) } returns setOf(folderTag)
 
         val result = mockMvc.perform(get("/folders/{id}/tags", 0))
             .andExpect(status().isOk)
             .andReturn()
 
         val resultResponse = objectMapper.readValue(result.response.contentAsString, object: TypeReference<List<TagDto>>() {})
-        assertThat(resultResponse).hasSize(1)
+        assertThat(resultResponse).hasSize(2)
         val tagResult = resultResponse.first()
         assertThat(tagResult).isEqualTo(tag)
+        assertThat(resultResponse[1]).isEqualTo(folderTag)
     }
 
     @Test


### PR DESCRIPTION
Closes #55.

The endpoint for creating tags is: `POST /tags/folders/add`.

For getting all the folders that have the applied tags: `POST /tags/folders`.

The existing endpoint `GET folders/{id}/tags` now also returns the folder tags along with the previous file tags.

The endpoint `POST tags/filesall` gets all the files that have the file and folder tags applied.