### PR TITLE
Hotfix/get folders by tags

### DIFF
--- a/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
@@ -1,5 +1,7 @@
 package com.guillermonegrete.gallery.data
 
+import com.guillermonegrete.gallery.repository.FolderDto
+
 data class Folder(
         val name:String,
         val coverUrl: String,
@@ -17,4 +19,6 @@ fun MediaFolder.toDto(fileName: String, ipAddress: String): Folder {
     return Folder(name, coverUrl, files.size, id)
 }
 
-fun MediaFolder.toDto() = Folder(name, coverFile?.filename ?: files.firstOrNull()?.filename ?: "", files.size, id)
+fun MediaFolder.toDto(ipAddress: String) = Folder(name, "http://$ipAddress/images/$name/${coverFile?.filename ?: files.firstOrNull()?.filename}", files.size, id)
+
+fun FolderDto.toFolder(ipAddress: String) = Folder(name, "http://$ipAddress/images/$name/$coverUrl", count, id)

--- a/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
@@ -3,14 +3,12 @@ package com.guillermonegrete.gallery.tags
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.guillermonegrete.gallery.config.NetworkConfig
-import com.guillermonegrete.gallery.data.Folder
 import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.MediaFolder
 import com.guillermonegrete.gallery.data.SimplePage
 import com.guillermonegrete.gallery.data.files.FileMapper
 import com.guillermonegrete.gallery.data.files.ImageEntity
 import com.guillermonegrete.gallery.data.files.dto.ImageFileDTO
-import com.guillermonegrete.gallery.data.toDto
 import com.guillermonegrete.gallery.repository.MediaFileRepository
 import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.tags.data.TagDto
@@ -42,9 +40,9 @@ import java.util.*
 
 @WebMvcTest
 class TagsControllerTest(
-    @Autowired val mockMvc: MockMvc,
-    @Autowired val mapper: FileMapper,
-    @Autowired val objectMapper: ObjectMapper,
+    @param:Autowired val mockMvc: MockMvc,
+    @param:Autowired val mapper: FileMapper,
+    @param:Autowired val objectMapper: ObjectMapper,
 ) {
 
     @MockkBean(relaxed = true)
@@ -262,23 +260,6 @@ class TagsControllerTest(
 
         val resultResponse = objectMapper.readValue(result.response.contentAsString, TagEntity::class.java)
         assertTagEqual(savedTag, resultResponse)
-    }
-
-    @Test
-    fun `Given valid tag id, when get folders by tags endpoint called, then files returned`(){
-        every { tagsRepository.existsById(0) } returns true
-        val folder = MediaFolder("my_folder")
-        every { mediaFolderRepository.findFoldersByTagsId(0, DEFAULT_PAGEABLE) } returns PageImpl(listOf(folder), DEFAULT_PAGEABLE, 1)
-
-        val result = mockMvc.perform(post("/tags/folders")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content("""[0]"""))
-            .andExpect(status().isOk)
-            .andReturn()
-
-        val resultResponse = objectMapper.readValue(result.response.contentAsString, object: TypeReference<SimplePage<Folder>>() {})
-        val expected = SimplePage(listOf(folder.toDto()), 1, 1)
-        assertThat(resultResponse).isEqualTo(expected)
     }
 
     //endregion


### PR DESCRIPTION
Renamed `tags/folders` to `/folders`
The endpoint now returns the expected format response.
Fixed not returning the full cover URL and returning just the filename.