### PR TITLE
Feature/#40 thumbnails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 
 plugins {
-	id("org.springframework.boot") version "3.4.1"
+	id("org.springframework.boot") version "3.5.7"
 	id("io.spring.dependency-management") version "1.0.9.RELEASE"
 	id ("org.flywaydb.flyway") version "7.14.0"
 	val kotlinVersion = "2.2.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 
 	implementation("net.bramp.ffmpeg:ffmpeg:0.8.0")
+    implementation("com.github.usefulness:webp-imageio:0.10.2")
 
 	// Database migration helper
 	implementation("org.flywaydb:flyway-core")

--- a/src/main/kotlin/com/guillermonegrete/gallery/DefaultFolderRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/DefaultFolderRepository.kt
@@ -38,6 +38,11 @@ class DefaultFolderRepository(
         return File(folder).listFiles()?.mapNotNull { file -> getMediaFile(file) } ?: emptyList()
     }
 
+    override fun createFolder(path: String): Boolean {
+        val folder = File(path)
+        return if (!folder.exists()) folder.mkdir() else false
+    }
+
     private fun getSuffix(imgFile: File): String?{
         val pos = imgFile.name.lastIndexOf(".")
         if (pos == -1) {

--- a/src/main/kotlin/com/guillermonegrete/gallery/FileUtils.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FileUtils.kt
@@ -1,0 +1,16 @@
+package com.guillermonegrete.gallery
+
+import java.io.File
+
+interface FileProvider {
+    fun createFromBase(path: String): File
+
+    fun getFile(parent: File, child: String): File
+}
+
+class DefaultFileProvider(private val basePath: String): FileProvider {
+
+    override fun createFromBase(path: String) = File(basePath, path)
+
+    override fun getFile(parent: File, child: String) = File(parent, child)
+}

--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
@@ -4,6 +4,7 @@ import com.guillermonegrete.gallery.config.NetworkConfig
 import com.guillermonegrete.gallery.data.Folder
 import com.guillermonegrete.gallery.data.PagedFolderResponse
 import com.guillermonegrete.gallery.data.SimplePage
+import com.guillermonegrete.gallery.data.files.FileInfo
 import com.guillermonegrete.gallery.data.files.FileMapper
 import com.guillermonegrete.gallery.data.files.PagedFileResponse
 import com.guillermonegrete.gallery.data.files.dto.FileDTO
@@ -12,7 +13,6 @@ import com.guillermonegrete.gallery.data.toFolder
 import com.guillermonegrete.gallery.repository.MediaFileRepository
 import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.tags.TagsRepository
-import com.guillermonegrete.gallery.thumbnails.thumbnailSizesMap
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
@@ -43,7 +43,7 @@ class FoldersController(
     fun folders(@RequestParam(required = false) query: String?, pageable: Pageable): PagedFolderResponse{
         val folders = if(query == null) getFolderPage(pageable) else getFolderPage(query, pageable)
         val page = SimplePage(folders.content, folders.totalPages, folders.totalElements.toInt())
-        return PagedFolderResponse(getFolderName(), page, thumbnailSizesMap)
+        return PagedFolderResponse(getFolderName(), page)
     }
 
     @GetMapping("/folders/{subFolder}")
@@ -82,6 +82,9 @@ class FoldersController(
         return PagedFileResponse(SimplePage(finalFiles, filesPage.totalPages, filesPage.totalElements.toInt()))
     }
 
+    @GetMapping("/files/info")
+    fun fileInfo() = FileInfo()
+
     @PatchMapping("/folder/{id}/cover/{fileId}")
     fun updateFolderCover(@PathVariable("id") id: Long, @PathVariable("fileId") fileId: Long): ResponseEntity<Folder> {
         val folder = mediaFolderRepo.findByIdOrNull(id) ?: throw RuntimeException("Folder id $id not found")
@@ -98,7 +101,7 @@ class FoldersController(
         if(ids.isEmpty()) throw Exception("The tag list is empty")
 
         val finalIds = ids.filter { tagRepo.existsById(it) }
-        if (finalIds.isEmpty()) return PagedFolderResponse(getFolderName(), SimplePage(), thumbnailSizesMap)
+        if (finalIds.isEmpty()) return PagedFolderResponse(getFolderName(), SimplePage())
 
         val sort = pageable.sort.firstOrNull()
         val foldersPage = if (query != null) {
@@ -135,7 +138,7 @@ class FoldersController(
         }
 
         val page  = SimplePage(foldersPage.content, foldersPage.totalPages, foldersPage.totalElements.toInt())
-        return PagedFolderResponse(getFolderName(), page, thumbnailSizesMap)
+        return PagedFolderResponse(getFolderName(), page)
     }
 
     /**

--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersController.kt
@@ -2,7 +2,6 @@ package com.guillermonegrete.gallery
 
 import com.guillermonegrete.gallery.config.NetworkConfig
 import com.guillermonegrete.gallery.data.Folder
-import com.guillermonegrete.gallery.data.MediaFolder
 import com.guillermonegrete.gallery.data.PagedFolderResponse
 import com.guillermonegrete.gallery.data.SimplePage
 import com.guillermonegrete.gallery.data.files.FileMapper

--- a/src/main/kotlin/com/guillermonegrete/gallery/FoldersRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/FoldersRepository.kt
@@ -11,4 +11,9 @@ interface FoldersRepository {
     fun getMediaInfo(path: String): MediaFile?
 
     fun getMedia(folder: String): List<MediaFile>
+
+    /**
+     * Returns true if a new folder was created, false if the folder already existed
+     */
+    fun createFolder(path: String): Boolean
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.gallery
 
 import com.guillermonegrete.gallery.services.FolderProcessingService
+import net.bramp.ffmpeg.FFprobe
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -24,6 +25,9 @@ class GalleryApplication{
             processingService.processFolder(basePath)
         }
     }
+
+    @Bean
+    fun ffprobe() = FFprobe()
 }
     
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
@@ -28,6 +28,9 @@ class GalleryApplication{
 
     @Bean
     fun ffprobe() = FFprobe()
+
+    @Bean
+    fun fileProvider() = DefaultFileProvider(basePath)
 }
     
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.gallery
 
 import com.guillermonegrete.gallery.services.FolderProcessingService
+import net.bramp.ffmpeg.FFmpegExecutor
 import net.bramp.ffmpeg.FFprobe
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
@@ -31,6 +32,9 @@ class GalleryApplication{
 
     @Bean
     fun fileProvider() = DefaultFileProvider(basePath)
+
+    @Bean
+    fun ffExecutor() = FFmpegExecutor()
 }
     
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
@@ -1,17 +1,20 @@
 package com.guillermonegrete.gallery.data
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.guillermonegrete.gallery.repository.FolderDto
 
 data class Folder(
-        val name:String,
-        val coverUrl: String,
-        val count: Int,
-        val id: Long,
+    val name:String,
+    val coverUrl: String,
+    val count: Int,
+    val id: Long,
 )
 
 data class PagedFolderResponse(
-        val name: String,
-        val page: SimplePage<Folder>
+    val name: String,
+    val page: SimplePage<Folder>,
+    @get:JsonProperty("thumbnail_sizes")
+    val thumbnailSizes: Map<String, Int>,
 )
 
 fun MediaFolder.toDto(fileName: String, ipAddress: String): Folder {

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
@@ -1,6 +1,5 @@
 package com.guillermonegrete.gallery.data
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.guillermonegrete.gallery.repository.FolderDto
 
 data class Folder(
@@ -13,8 +12,6 @@ data class Folder(
 data class PagedFolderResponse(
     val name: String,
     val page: SimplePage<Folder>,
-    @get:JsonProperty("thumbnail_sizes")
-    val thumbnailSizes: Map<String, Int>,
 )
 
 fun MediaFolder.toDto(fileName: String, ipAddress: String): Folder {

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/File.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/File.kt
@@ -1,0 +1,14 @@
+package com.guillermonegrete.gallery.data.files
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.guillermonegrete.gallery.data.SimplePage
+import com.guillermonegrete.gallery.data.files.dto.FileDTO
+import com.guillermonegrete.gallery.thumbnails.thumbnailSizesMap
+
+data class PagedFileResponse(
+    @get:JsonUnwrapped
+    val page: SimplePage<FileDTO>,
+    @get:JsonProperty("thumbnail_sizes")
+    val thumbnailSizes: Map<String, Int> = thumbnailSizesMap,
+)

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/File.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/File.kt
@@ -9,6 +9,9 @@ import com.guillermonegrete.gallery.thumbnails.thumbnailSizesMap
 data class PagedFileResponse(
     @get:JsonUnwrapped
     val page: SimplePage<FileDTO>,
+)
+
+data class FileInfo(
     @get:JsonProperty("thumbnail_sizes")
     val thumbnailSizes: Map<String, Int> = thumbnailSizesMap,
 )

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
@@ -3,14 +3,14 @@ package com.guillermonegrete.gallery.data.files
 import com.guillermonegrete.gallery.data.Folder
 import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.files.dto.*
-import com.guillermonegrete.gallery.tags.data.toDto
+import com.guillermonegrete.gallery.tags.data.toBaseDto
 import org.springframework.stereotype.Component
 
 @Component
 class FileMapper {
 
     fun toDto(e: MediaFile, url: String): FileDTO {
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toBaseDto(), e.id)
         return when(e){
             is VideoEntity -> VideoFileDTO(e.duration, base)
             is ImageEntity -> ImageFileDTO(base)
@@ -20,7 +20,7 @@ class FileMapper {
 
     fun toDtoWithHost(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toBaseDto(), e.id)
         return when(e){
             is VideoEntity -> VideoFileDTO(e.duration, base)
             is ImageEntity -> ImageFileDTO(base)
@@ -31,7 +31,7 @@ class FileMapper {
     fun toSingleDto(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
         val folder = Folder(e.folder.name, "", e.folder.files.size, e.folder.id)
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toBaseDto(), e.id)
         return when(e){
             is VideoEntity -> SingleVideoFile(folder, VideoFileDTO(e.duration, base))
             is ImageEntity -> SingleImageFile(folder, ImageFileDTO(base))

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
@@ -3,13 +3,14 @@ package com.guillermonegrete.gallery.data.files
 import com.guillermonegrete.gallery.data.Folder
 import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.files.dto.*
+import com.guillermonegrete.gallery.tags.data.toDto
 import org.springframework.stereotype.Component
 
 @Component
 class FileMapper {
 
     fun toDto(e: MediaFile, url: String): FileDTO {
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
         return when(e){
             is VideoEntity -> VideoFileDTO(e.duration, base)
             is ImageEntity -> ImageFileDTO(base)
@@ -19,7 +20,7 @@ class FileMapper {
 
     fun toDtoWithHost(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
         return when(e){
             is VideoEntity -> VideoFileDTO(e.duration, base)
             is ImageEntity -> ImageFileDTO(base)
@@ -30,7 +31,7 @@ class FileMapper {
     fun toSingleDto(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
         val folder = Folder(e.folder.name, "", e.folder.files.size, e.folder.id)
-        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toDto(), e.id)
         return when(e){
             is VideoEntity -> SingleVideoFile(folder, VideoFileDTO(e.duration, base))
             is ImageEntity -> SingleImageFile(folder, ImageFileDTO(base))

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
@@ -9,29 +9,32 @@ import org.springframework.stereotype.Component
 class FileMapper {
 
     fun toDto(e: MediaFile, url: String): FileDTO {
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
         return when(e){
-            is VideoEntity -> VideoFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.duration, e.tags, e.id)
-            is ImageEntity -> ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
-            else -> ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
+            is VideoEntity -> VideoFileDTO(e.duration, base)
+            is ImageEntity -> ImageFileDTO(base)
+            else -> ImageFileDTO(base)
         }
     }
 
     fun toDtoWithHost(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
         return when(e){
-            is VideoEntity -> VideoFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.duration, e.tags, e.id)
-            is ImageEntity -> ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
-            else -> ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
+            is VideoEntity -> VideoFileDTO(e.duration, base)
+            is ImageEntity -> ImageFileDTO(base)
+            else -> ImageFileDTO(base)
         }
     }
 
     fun toSingleDto(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
         val folder = Folder(e.folder.name, "", e.folder.files.size, e.folder.id)
+        val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id)
         return when(e){
-            is VideoEntity -> SingleVideoFile(folder, VideoFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.duration, e.tags, e.id))
-            is ImageEntity -> SingleImageFile(folder, ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id))
-            else -> SingleImageFile(folder, ImageFileDTO(url, e.width, e.height, e.creationDate, e.lastModified, e.tags, e.id))
+            is VideoEntity -> SingleVideoFile(folder, VideoFileDTO(e.duration, base))
+            is ImageEntity -> SingleImageFile(folder, ImageFileDTO(base))
+            else -> SingleImageFile(folder, ImageFileDTO(base))
         }
     }
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
@@ -1,5 +1,6 @@
 package com.guillermonegrete.gallery.data.files.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.guillermonegrete.gallery.data.Folder
@@ -11,36 +12,39 @@ sealed class FileDTO(
     val type: FileType
 )
 
-data class ImageFileDTO(
+data class BaseFile(
     val url: String,
+    val filename: String,
     val width: Int,
     val height: Int,
     val creationDate: Instant,
     val lastModified: Instant,
     val tags: Set<TagEntity>,
     val id: Long,
+)
+
+data class ImageFileDTO(
+    @get:JsonUnwrapped
+    val base: BaseFile,
 ): FileDTO(FileType.Image)
 
 data class VideoFileDTO(
-    val url: String,
-    val width: Int,
-    val height: Int,
-    val creationDate: Instant,
-    val lastModified: Instant,
     val duration: Int,
-    val tags: Set<TagEntity>,
-    val id: Long,
+    @get:JsonUnwrapped
+    val base: BaseFile,
 ): FileDTO(FileType.Video)
 
 data class SingleImageFile(
     val folder: Folder,
-    @JsonUnwrapped
+    @JsonIgnoreProperties("file_type") // avoid duplicating the field
+    @get:JsonUnwrapped
     val dto: ImageFileDTO,
 ): FileDTO(FileType.Image)
 
 data class SingleVideoFile(
     val folder: Folder,
-    @JsonUnwrapped
+    @JsonIgnoreProperties("file_type")
+    @get:JsonUnwrapped
     val dto: VideoFileDTO,
 ): FileDTO(FileType.Video)
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.guillermonegrete.gallery.data.Folder
-import com.guillermonegrete.gallery.tags.data.TagDto
+import com.guillermonegrete.gallery.tags.data.BaseTag
 import java.time.Instant
 
 sealed class FileDTO(
@@ -19,7 +19,7 @@ data class BaseFile(
     val height: Int,
     val creationDate: Instant,
     val lastModified: Instant,
-    val tags: Set<TagDto>,
+    val tags: Set<BaseTag>,
     val id: Long,
 )
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/dto/FileDTO.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import com.guillermonegrete.gallery.data.Folder
-import com.guillermonegrete.gallery.tags.data.TagEntity
+import com.guillermonegrete.gallery.tags.data.TagDto
 import java.time.Instant
 
 sealed class FileDTO(
@@ -19,7 +19,7 @@ data class BaseFile(
     val height: Int,
     val creationDate: Instant,
     val lastModified: Instant,
-    val tags: Set<TagEntity>,
+    val tags: Set<TagDto>,
     val id: Long,
 )
 

--- a/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
@@ -1,0 +1,46 @@
+package com.guillermonegrete.gallery.services.thumbnail
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.imageio.ImageIO
+
+@Service
+class ThumbnailService(@Value("\${final.path}") private val basePath: String) {
+
+    fun generateThumbnail(folder: String, filename: String, type: ThumbnailType): ByteArray {
+
+        // Generate scaled image
+        val baseFolder = File(basePath, folder)
+        val originalFile = File(baseFolder, filename)
+        val originalImage = ImageIO.read(originalFile)
+        val newHeight = (type.size * (originalImage.height.toFloat() / originalImage.width)).toInt()
+        val buffImg = BufferedImage(type.size, newHeight, BufferedImage.TYPE_INT_RGB)
+        buffImg.createGraphics().drawImage(originalImage.getScaledInstance(type.size, newHeight, BufferedImage.SCALE_SMOOTH), 0, 0, null)
+
+        // Write to file
+        val thumbnailsFolder = File(baseFolder, THUMBNAILS_FOLDER)
+        if (!thumbnailsFolder.exists()) thumbnailsFolder.mkdir()
+        val newFilename = originalFile.nameWithoutExtension + "-" + type.name.lowercase() + "." + originalFile.extension
+        val newFile = File(thumbnailsFolder, newFilename)
+        ImageIO.write(buffImg, THUMBNAIL_EXT, newFile)
+
+        // Return byte data
+        val baos = ByteArrayOutputStream()
+        ImageIO.write(buffImg, THUMBNAIL_EXT, baos)
+        return baos.toByteArray()
+    }
+
+    companion object {
+        const val THUMBNAILS_FOLDER = ".thumbnails"
+        const val THUMBNAIL_EXT = "webp"
+    }
+
+    enum class ThumbnailType(val size: Int) {
+        Small(100),
+        Medium(200),
+        Large(300)
+    }
+}

--- a/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
@@ -1,7 +1,9 @@
 package com.guillermonegrete.gallery.services.thumbnail
 
 import net.bramp.ffmpeg.FFmpegExecutor
+import net.bramp.ffmpeg.FFprobe
 import net.bramp.ffmpeg.builder.FFmpegBuilder
+import net.bramp.ffmpeg.probe.FFmpegStream
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.awt.image.BufferedImage
@@ -10,7 +12,10 @@ import java.io.File
 import javax.imageio.ImageIO
 
 @Service
-class ThumbnailService(@param:Value("\${final.path}") private val basePath: String) {
+class ThumbnailService(
+    private val ffprobe: FFprobe,
+    @param:Value("\${final.path}") private val basePath: String,
+) {
 
     fun generateThumbnail(folder: String, filename: String, type: ThumbnailType): ByteArray {
 
@@ -32,30 +37,53 @@ class ThumbnailService(@param:Value("\${final.path}") private val basePath: Stri
         // Otherwise generate new thumbnail
         val originalImage = ImageIO.read(originalFile)
         val img = if (originalImage != null) {
-            val newHeight = (type.size * (originalImage.height.toFloat() / originalImage.width)).toInt()
-            val buffImg = BufferedImage(type.size, newHeight, BufferedImage.TYPE_INT_RGB)
-            buffImg.createGraphics().drawImage(originalImage.getScaledInstance(type.size, newHeight, BufferedImage.SCALE_SMOOTH), 0, 0, null)
+            if (originalImage.width <= type.size) {
+                originalImage
+            } else {
+                val newHeight = (type.size * (originalImage.height.toFloat() / originalImage.width)).toInt()
+                val buffImg = BufferedImage(type.size, newHeight, BufferedImage.TYPE_INT_RGB)
+                buffImg.createGraphics().drawImage(originalImage.getScaledInstance(type.size, newHeight, BufferedImage.SCALE_SMOOTH), 0, 0, null)
 
-            ImageIO.write(buffImg, THUMBNAIL_EXT, newFile)
-            buffImg
+                ImageIO.write(buffImg, THUMBNAIL_EXT, newFile)
+                buffImg
+            }
         } else {
-            val builder = FFmpegBuilder()
-                .setInput(originalFile.absolutePath)
-                .addOutput(newFile.absolutePath)
-                .setVideoCodec("libwebp")
-                .setFrames(1)
-                .setVideoFilter("scale=${type.size}:-1")
-                .done()
-            val executor = FFmpegExecutor()
-            executor.createJob(builder).run()
-
-            ImageIO.read(newFile)
+            generateVideoThumbnail(originalFile, newFile, type.size, thumbnailsFolder)
         }
 
         // Return byte data
         val baos = ByteArrayOutputStream()
         ImageIO.write(img, THUMBNAIL_EXT, baos)
         return baos.toByteArray()
+    }
+
+    private fun generateVideoThumbnail(
+        originalFile: File,
+        newFile: File,
+        newSize: Int,
+        thumbnailsFolder: File
+    ): BufferedImage? {
+
+        val stream = ffprobe.probe(originalFile.absolutePath)?.streams?.find { it.codec_type == FFmpegStream.CodecType.VIDEO }
+        val originalIsBigger = stream != null && stream.width > newSize
+
+        val defaultThumbnailFile = File(thumbnailsFolder,   originalFile.nameWithoutExtension + "-default." + THUMBNAIL_EXT)
+        if (!originalIsBigger && defaultThumbnailFile.exists()) {
+            return ImageIO.read(defaultThumbnailFile)
+        }
+
+        val targetFile = if (originalIsBigger) newFile else defaultThumbnailFile
+        val builder = FFmpegBuilder()
+            .setInput(originalFile.absolutePath)
+            .addOutput(targetFile.absolutePath)
+            .setVideoCodec("libwebp")
+            .setFrames(1)
+
+        if (originalIsBigger) builder.setVideoFilter("scale=${newSize}:-1")
+
+        val executor = FFmpegExecutor()
+        executor.createJob(builder.done()).run()
+        return ImageIO.read(targetFile)
     }
 
     companion object {

--- a/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/services/thumbnail/ThumbnailService.kt
@@ -1,5 +1,7 @@
 package com.guillermonegrete.gallery.services.thumbnail
 
+import net.bramp.ffmpeg.FFmpegExecutor
+import net.bramp.ffmpeg.builder.FFmpegBuilder
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.awt.image.BufferedImage
@@ -8,28 +10,51 @@ import java.io.File
 import javax.imageio.ImageIO
 
 @Service
-class ThumbnailService(@Value("\${final.path}") private val basePath: String) {
+class ThumbnailService(@param:Value("\${final.path}") private val basePath: String) {
 
     fun generateThumbnail(folder: String, filename: String, type: ThumbnailType): ByteArray {
 
-        // Generate scaled image
         val baseFolder = File(basePath, folder)
         val originalFile = File(baseFolder, filename)
-        val originalImage = ImageIO.read(originalFile)
-        val newHeight = (type.size * (originalImage.height.toFloat() / originalImage.width)).toInt()
-        val buffImg = BufferedImage(type.size, newHeight, BufferedImage.TYPE_INT_RGB)
-        buffImg.createGraphics().drawImage(originalImage.getScaledInstance(type.size, newHeight, BufferedImage.SCALE_SMOOTH), 0, 0, null)
 
-        // Write to file
+        // Check if thumbnail already exists
         val thumbnailsFolder = File(baseFolder, THUMBNAILS_FOLDER)
         if (!thumbnailsFolder.exists()) thumbnailsFolder.mkdir()
-        val newFilename = originalFile.nameWithoutExtension + "-" + type.name.lowercase() + "." + originalFile.extension
+        val newFilename = originalFile.nameWithoutExtension + "-" + type.name.lowercase() + "." + THUMBNAIL_EXT
         val newFile = File(thumbnailsFolder, newFilename)
-        ImageIO.write(buffImg, THUMBNAIL_EXT, newFile)
+        if (newFile.exists()) {
+            val thumbnail = ImageIO.read(newFile)
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(thumbnail, THUMBNAIL_EXT, baos)
+            return baos.toByteArray()
+        }
+
+        // Otherwise generate new thumbnail
+        val originalImage = ImageIO.read(originalFile)
+        val img = if (originalImage != null) {
+            val newHeight = (type.size * (originalImage.height.toFloat() / originalImage.width)).toInt()
+            val buffImg = BufferedImage(type.size, newHeight, BufferedImage.TYPE_INT_RGB)
+            buffImg.createGraphics().drawImage(originalImage.getScaledInstance(type.size, newHeight, BufferedImage.SCALE_SMOOTH), 0, 0, null)
+
+            ImageIO.write(buffImg, THUMBNAIL_EXT, newFile)
+            buffImg
+        } else {
+            val builder = FFmpegBuilder()
+                .setInput(originalFile.absolutePath)
+                .addOutput(newFile.absolutePath)
+                .setVideoCodec("libwebp")
+                .setFrames(1)
+                .setVideoFilter("scale=${type.size}:-1")
+                .done()
+            val executor = FFmpegExecutor()
+            executor.createJob(builder).run()
+
+            ImageIO.read(newFile)
+        }
 
         // Return byte data
         val baos = ByteArrayOutputStream()
-        ImageIO.write(buffImg, THUMBNAIL_EXT, baos)
+        ImageIO.write(img, THUMBNAIL_EXT, baos)
         return baos.toByteArray()
     }
 
@@ -37,10 +62,15 @@ class ThumbnailService(@Value("\${final.path}") private val basePath: String) {
         const val THUMBNAILS_FOLDER = ".thumbnails"
         const val THUMBNAIL_EXT = "webp"
     }
+}
 
-    enum class ThumbnailType(val size: Int) {
-        Small(100),
-        Medium(200),
-        Large(300)
+enum class ThumbnailType(val size: Int) {
+    Small(100),
+    Medium(200),
+    Large(300);
+
+    companion object {
+        fun getThumbnailType(size: String) =
+            ThumbnailType.entries.find { it.name.compareTo(size, true) == 0 }
     }
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -16,7 +16,8 @@ interface FileTagsRepository: JpaRepository<TagFile, Long>{
 
     fun findByIdIn(ids: List<Long>): List<TagFile>
 
-    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, SIZE(t.files), t.creationDate, t.id) FROM TagFile AS t")
+    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagFile AS t " +
+            "JOIN t.files GROUP BY t.id")
     fun getFileTags(): Set<TagFileDto>
 
     @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/TagsRepository.kt
@@ -16,8 +16,8 @@ interface FileTagsRepository: JpaRepository<TagFile, Long>{
 
     fun findByIdIn(ids: List<Long>): List<TagFile>
 
-    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagFile AS t " +
-            "JOIN t.files GROUP BY t.id")
+    @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(f.id), t.creationDate, t.id) FROM TagFile AS t " +
+            "LEFT JOIN t.files AS f GROUP BY t.id")
     fun getFileTags(): Set<TagFileDto>
 
     @Query("SELECT new com.guillermonegrete.gallery.tags.data.TagFileDto(t.name, COUNT(t.id), t.creationDate, t.id) FROM TagEntity AS t " +

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
@@ -15,7 +15,7 @@ sealed class TagDto(
 @JsonTypeName("File")
 data class TagFileDto(
     val name: String,
-    val count: Long,
+    val count: Long?,
     /**
      * By default, the db saves in seconds, truncate to avoid having different milliseconds
      */

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagDto.kt
@@ -15,7 +15,7 @@ sealed class TagDto(
 @JsonTypeName("File")
 data class TagFileDto(
     val name: String,
-    val count: Long?,
+    val count: Long,
     /**
      * By default, the db saves in seconds, truncate to avoid having different milliseconds
      */
@@ -33,6 +33,16 @@ data class TagFolderDto(
     val creationDate: Instant = Instant.now().truncatedTo(ChronoUnit.SECONDS),
     val id: Long = 0,
 ): TagDto(TagType.Folder)
+
+/**
+ * DTO for [TagEntity].
+ * Use when the count and type are not required.
+ */
+data class BaseTag(
+    val name: String,
+    val creationDate: Instant,
+    val id: Long,
+)
 
 enum class TagType{
     Folder,

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
@@ -27,3 +27,7 @@ open class TagFile(
 ): TagEntity(name, creationDate, id)
 
 fun TagFile.toDto() = TagFileDto(name, files.size.toLong(), creationDate, id)
+
+fun TagFile.toSimpleDto() = TagFileDto(name, null, creationDate, id)
+
+fun Set<TagFile>.toDto() = map(TagFile::toSimpleDto).toSet()

--- a/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/tags/data/TagFile.kt
@@ -28,6 +28,6 @@ open class TagFile(
 
 fun TagFile.toDto() = TagFileDto(name, files.size.toLong(), creationDate, id)
 
-fun TagFile.toSimpleDto() = TagFileDto(name, null, creationDate, id)
+fun TagFile.toBaseDto() = BaseTag(name, creationDate, id)
 
-fun Set<TagFile>.toDto() = map(TagFile::toSimpleDto).toSet()
+fun Set<TagFile>.toBaseDto() = map(TagFile::toBaseDto).toSet()

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -1,6 +1,7 @@
 package com.guillermonegrete.gallery.thumbnails
 
 import com.guillermonegrete.gallery.FileProvider
+import com.guillermonegrete.gallery.thumbnails.ThumbnailService.Companion.THUMBNAIL_EXT
 import net.bramp.ffmpeg.FFmpegExecutor
 import net.bramp.ffmpeg.FFprobe
 import net.bramp.ffmpeg.builder.FFmpegBuilder
@@ -9,11 +10,14 @@ import org.springframework.stereotype.Service
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
+import java.nio.file.Files
 import javax.imageio.ImageIO
 
 @Service
 class ThumbnailService(
-    private val ffprobe: FFprobe,
+    private val ffProbe: FFprobe,
+    private val ffExecutor: FFmpegExecutor,
     private val fileProvider: FileProvider,
 ) {
 
@@ -25,12 +29,19 @@ class ThumbnailService(
         // Check if thumbnail already exists
         val thumbnailsFolder = fileProvider.getFile(baseFolder, THUMBNAILS_FOLDER)
         if (!thumbnailsFolder.exists()) thumbnailsFolder.mkdir()
-        val newFilename = originalFile.nameWithoutExtension + "-" + type.name.lowercase() + "." + THUMBNAIL_EXT
+        val newFilename = type.filename(originalFile.nameWithoutExtension)
         val newFile = fileProvider.getFile(thumbnailsFolder, newFilename)
         if (newFile.exists()) {
             val thumbnail = ImageIO.read(newFile)
             val baos = ByteArrayOutputStream()
             ImageIO.write(thumbnail, THUMBNAIL_EXT, baos)
+            return baos.toByteArray()
+        }
+
+        // Return original size thumbnail (for videos only)
+        if (type == ThumbnailType.Original) {
+            val baos = ByteArrayOutputStream()
+            ImageIO.write(generateVideoThumbnail(originalFile, newFile), THUMBNAIL_EXT, baos)
             return baos.toByteArray()
         }
 
@@ -64,15 +75,15 @@ class ThumbnailService(
         thumbnailsFolder: File
     ): BufferedImage? {
 
-        val stream = ffprobe.probe(originalFile.absolutePath)?.streams?.find { it.codec_type == FFmpegStream.CodecType.VIDEO }
+        val stream = ffProbe.probe(originalFile.absolutePath)?.streams?.find { it.codec_type == FFmpegStream.CodecType.VIDEO }
         val originalIsBigger = stream != null && stream.width > newSize
 
-        val defaultThumbnailFile = fileProvider.getFile(thumbnailsFolder,   originalFile.nameWithoutExtension + "-default." + THUMBNAIL_EXT)
-        if (!originalIsBigger && defaultThumbnailFile.exists()) {
-            return ImageIO.read(defaultThumbnailFile)
+        var targetFile = newFile
+        if (!originalIsBigger) {
+            targetFile = fileProvider.getFile(thumbnailsFolder, ThumbnailType.Original.filename(originalFile.nameWithoutExtension))
+            if (targetFile.exists()) return ImageIO.read(targetFile)
         }
 
-        val targetFile = if (originalIsBigger) newFile else defaultThumbnailFile
         val builder = FFmpegBuilder()
             .setInput(originalFile.absolutePath)
             .addOutput(targetFile.absolutePath)
@@ -81,9 +92,22 @@ class ThumbnailService(
 
         if (originalIsBigger) builder.setVideoFilter("scale=${newSize}:-1")
 
-        val executor = FFmpegExecutor()
-        executor.createJob(builder.done()).run()
+        ffExecutor.createJob(builder.done()).run()
         return ImageIO.read(targetFile)
+    }
+
+    fun generateVideoThumbnail(originalFile: File, newFile: File): BufferedImage {
+        val mimeType = Files.probeContentType(originalFile.toPath())
+        if (!mimeType.startsWith("video/")) throw IOException("File is not a video, original size is only available for videos")
+
+        val builder = FFmpegBuilder()
+            .setInput(originalFile.absolutePath)
+            .addOutput(newFile.absolutePath)
+            .setVideoCodec("libwebp")
+            .setFrames(1)
+
+        ffExecutor.createJob(builder.done()).run()
+        return ImageIO.read(newFile)
     }
 
     companion object {
@@ -93,12 +117,16 @@ class ThumbnailService(
 }
 
 enum class ThumbnailType(val size: Int) {
+    Original(0),
     Small(100),
-    Medium(300),
-    Large(500);
+    Medium(350),
+    Large(600),
+    ExtraLarge(850);
 
     companion object {
         fun getThumbnailType(size: String) =
             entries.find { it.name.compareTo(size, true) == 0 }
     }
 }
+
+fun ThumbnailType.filename(nameNoExt: String) = "$nameNoExt-${name.lowercase()}.$THUMBNAIL_EXT"

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -111,10 +111,11 @@ class ThumbnailService(
     }
 
     companion object {
-        const val THUMBNAILS_FOLDER = ".thumbnails"
         const val THUMBNAIL_EXT = "webp"
     }
 }
+
+const val THUMBNAILS_FOLDER = ".thumbnails"
 
 enum class ThumbnailType(val size: Int) {
     Original(0),

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -94,8 +94,8 @@ class ThumbnailService(
 
 enum class ThumbnailType(val size: Int) {
     Small(100),
-    Medium(200),
-    Large(300);
+    Medium(300),
+    Large(500);
 
     companion object {
         fun getThumbnailType(size: String) =

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -1,4 +1,4 @@
-package com.guillermonegrete.gallery.services.thumbnail
+package com.guillermonegrete.gallery.thumbnails
 
 import net.bramp.ffmpeg.FFmpegExecutor
 import net.bramp.ffmpeg.FFprobe
@@ -99,6 +99,6 @@ enum class ThumbnailType(val size: Int) {
 
     companion object {
         fun getThumbnailType(size: String) =
-            ThumbnailType.entries.find { it.name.compareTo(size, true) == 0 }
+            entries.find { it.name.compareTo(size, true) == 0 }
     }
 }

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
@@ -1,7 +1,5 @@
 package com.guillermonegrete.gallery.thumbnails
 
-import com.guillermonegrete.gallery.services.thumbnail.ThumbnailService
-import com.guillermonegrete.gallery.services.thumbnail.ThumbnailType
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
@@ -1,0 +1,29 @@
+package com.guillermonegrete.gallery.thumbnails
+
+import com.guillermonegrete.gallery.services.thumbnail.ThumbnailService
+import com.guillermonegrete.gallery.services.thumbnail.ThumbnailType
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ThumbnailsController(private val thumbnailService: ThumbnailService) {
+
+    @GetMapping("/thumbnails/{subFolder}/{filename}", produces = ["image/webp"])
+    @ResponseBody
+    fun getThumbnail(
+        @PathVariable subFolder: String,
+        @PathVariable filename: String,
+        @RequestParam("size") size: String?
+    ): ResponseEntity<ByteArray> {
+        val type = if (size == null) ThumbnailType.Small else ThumbnailType.getThumbnailType(size) ?: ThumbnailType.Small
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.parseMediaType("image/webp"))
+            .body(thumbnailService.generateThumbnail(subFolder, filename, type))
+    }
+}

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
@@ -27,3 +27,5 @@ class ThumbnailsController(private val thumbnailService: ThumbnailService) {
             .body(thumbnailService.generateThumbnail(subFolder, filename, type))
     }
 }
+
+val thumbnailSizesMap = ThumbnailType.entries.associate { it.name.lowercase() to it.size }

--- a/src/test/kotlin/com/guillermonegrete/gallery/FakeFolderRepository.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/FakeFolderRepository.kt
@@ -31,6 +31,10 @@ class FakeFolderRepository: FoldersRepository {
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
+    override fun createFolder(path: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
     @VisibleForTesting
     fun addFolders(vararg folders: String) {
         for (folder in folders) {

--- a/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
@@ -11,7 +11,6 @@ import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.services.FolderFetchingService
 import com.guillermonegrete.gallery.tags.TagsControllerTest.Companion.DEFAULT_PAGEABLE
 import com.guillermonegrete.gallery.tags.TagsRepository
-import com.guillermonegrete.gallery.thumbnails.thumbnailSizesMap
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
@@ -79,7 +78,6 @@ class FoldersControllerTest(
             path,
             SimplePage(subList.map { Folder(it.name, "http://$ipAddress/images/${it.name}/image.jpg", 1, it.id) },
             2, content.size),
-            thumbnailSizesMap,
         )
         val result = mockMvc.perform(get("/folders")).andDo(print())
             .andExpect(status().isOk)
@@ -138,7 +136,7 @@ class FoldersControllerTest(
             .andReturn()
 
         val resultResponse = objectMapper.readValue(result.response.contentAsString, PagedFolderResponse::class.java)
-        val expected = PagedFolderResponse(path, SimplePage(listOf(folder.toDto(ipAddress)), 1, 1), thumbnailSizesMap)
+        val expected = PagedFolderResponse(path, SimplePage(listOf(folder.toDto(ipAddress)), 1, 1))
         assertThat(resultResponse).isEqualTo(expected)
     }
 

--- a/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
@@ -11,6 +11,7 @@ import com.guillermonegrete.gallery.repository.MediaFolderRepository
 import com.guillermonegrete.gallery.services.FolderFetchingService
 import com.guillermonegrete.gallery.tags.TagsControllerTest.Companion.DEFAULT_PAGEABLE
 import com.guillermonegrete.gallery.tags.TagsRepository
+import com.guillermonegrete.gallery.thumbnails.thumbnailSizesMap
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
@@ -77,7 +78,8 @@ class FoldersControllerTest(
         val expected = PagedFolderResponse(
             path,
             SimplePage(subList.map { Folder(it.name, "http://$ipAddress/images/${it.name}/image.jpg", 1, it.id) },
-            2, content.size)
+            2, content.size),
+            thumbnailSizesMap,
         )
         val result = mockMvc.perform(get("/folders")).andDo(print())
             .andExpect(status().isOk)
@@ -136,7 +138,7 @@ class FoldersControllerTest(
             .andReturn()
 
         val resultResponse = objectMapper.readValue(result.response.contentAsString, PagedFolderResponse::class.java)
-        val expected = PagedFolderResponse(path, SimplePage(listOf(folder.toDto(ipAddress)), 1, 1))
+        val expected = PagedFolderResponse(path, SimplePage(listOf(folder.toDto(ipAddress)), 1, 1), thumbnailSizesMap)
         assertThat(resultResponse).isEqualTo(expected)
     }
 

--- a/src/test/kotlin/com/guillermonegrete/gallery/services/FolderProcessingServiceTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/services/FolderProcessingServiceTest.kt
@@ -1,5 +1,6 @@
 package com.guillermonegrete.gallery.services
 
+import com.guillermonegrete.gallery.FileProvider
 import com.guillermonegrete.gallery.FoldersRepository
 import com.guillermonegrete.gallery.data.MediaFile
 import com.guillermonegrete.gallery.data.MediaFolder
@@ -7,11 +8,16 @@ import com.guillermonegrete.gallery.data.files.ImageEntity
 import com.guillermonegrete.gallery.data.files.VideoEntity
 import com.guillermonegrete.gallery.repository.MediaFileRepository
 import com.guillermonegrete.gallery.repository.MediaFolderRepository
+import com.guillermonegrete.gallery.thumbnails.THUMBNAILS_FOLDER
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.io.File
 
+@ExtendWith(MockKExtension::class)
 class FolderProcessingServiceTest{
 
     private lateinit var service: FolderProcessingService
@@ -20,11 +26,20 @@ class FolderProcessingServiceTest{
     @MockK private lateinit var fileEntityRepo: MediaFileRepository
     @MockK private lateinit var folderEntityRepo: MediaFolderRepository
     @MockK private lateinit var fetchingService: FolderFetchingService
+    @MockK private lateinit var fileProvider: FileProvider
 
     @BeforeEach
     fun setUp(){
-        MockKAnnotations.init(this)
-        service = FolderProcessingService(folderRepository, fileEntityRepo, folderEntityRepo, fetchingService)
+        service = FolderProcessingService(folderRepository, fileEntityRepo, folderEntityRepo, fileProvider, fetchingService)
+
+        // Mocks for the thumbnails
+        val mockFolder = mockk<File>()
+        val mockThumbnailFolder = mockk<File>()
+        val thumbnailPath = "/thumbnail"
+        every { mockThumbnailFolder.absolutePath } returns thumbnailPath
+        every { fileProvider.createFromBase(any()) } returns mockFolder
+        every { fileProvider.getFile(mockFolder, THUMBNAILS_FOLDER) } returns mockThumbnailFolder
+        every { folderRepository.createFolder(thumbnailPath) } returns false
     }
 
     @Test

--- a/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
@@ -17,6 +17,7 @@ import com.guillermonegrete.gallery.tags.data.TagFile
 import com.guillermonegrete.gallery.tags.data.TagFileDto
 import com.guillermonegrete.gallery.tags.data.TagFolder
 import com.guillermonegrete.gallery.tags.data.TagFolderDto
+import com.guillermonegrete.gallery.thumbnails.ThumbnailService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
@@ -53,6 +54,7 @@ class TagsControllerTest(
     @MockkBean private lateinit var folderTagsRepository: FolderTagsRepository
     @MockkBean private lateinit var mediaFolderRepository: MediaFolderRepository
     @MockkBean private lateinit var mediaFileRepository: MediaFileRepository
+    @MockkBean private lateinit var thumbnailService: ThumbnailService
     @MockkBean private lateinit var networkConfig: NetworkConfig
 
     private val ipAddress = "dummy-address"

--- a/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/tags/TagsControllerTest.kt
@@ -21,6 +21,7 @@ import com.guillermonegrete.gallery.thumbnails.ThumbnailService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -159,16 +160,19 @@ class TagsControllerTest(
         every { mediaFileRepository.saveAll<MediaFile>(any()) } returns listOf()
 
         // Using string comparison instead of
-        val expectedResponse =
-            """[{"url":"http://$ipAddress/images//file_1","width":0,"height":0,"creationDate":"$date","lastModified":"$date","tags":[{"name":"my_tag","creationDate":"$date","id":0}],"id":0,"file_type":"Image"},""" +
-            """{"url":"http://$ipAddress/images//file_2","width":0,"height":0,"creationDate":"$date","lastModified":"$date","tags":[{"name":"my_tag","creationDate":"$date","id":0}],"id":0,"file_type":"Image"},""" +
-            """{"url":"http://$ipAddress/images//file_3","width":0,"height":0,"creationDate":"$date","lastModified":"$date","tags":[{"name":"my_tag","creationDate":"$date","id":0}],"id":0,"file_type":"Image"}]"""
+        val expectedResponse = files.map {
+            mapper.toDtoWithHost(MediaFile(it.filename, creationDate = date, lastModified = date, tags = mutableSetOf(savedTag)), ipAddress)
+        }
 
-        mockMvc.perform(post("/tags/{id}/files", tagId)
+        val result = mockMvc.perform(post("/tags/{id}/files", tagId)
             .contentType(MediaType.APPLICATION_JSON)
             .content("""[2,3,4]"""))
             .andExpect(status().isOk)
-            .andExpect(content().string(expectedResponse))
+            .andReturn()
+
+        val resultResponse = objectMapper.readValue(result.response.contentAsString, object: TypeReference<List<ImageFileDTO>>() {})
+        print(expectedResponse)
+        assertEquals(expectedResponse, resultResponse)
     }
 
     @Test

--- a/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
@@ -58,7 +58,7 @@ class ThumbnailServiceTest {
         // Generate the base and thumbnail folders, and the original and thumbnai file mocks
         every { fileProvider.createFromBase(DUMMY_FOLDER) } returns mockBaseFolder
         every { fileProvider.getFile(mockBaseFolder, DUMMY_FILE) } returns mockOriginalFile
-        every { fileProvider.getFile(mockBaseFolder, ThumbnailService.THUMBNAILS_FOLDER) } returns mockThumbnailsBase
+        every { fileProvider.getFile(mockBaseFolder, THUMBNAILS_FOLDER) } returns mockThumbnailsBase
         val thumbnailFilename = ThumbnailType.Small.filename(DUMMY_FILE_NO_EXT)
         every { fileProvider.getFile(mockThumbnailsBase, thumbnailFilename) } returns mockThumbnail
 

--- a/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
@@ -1,0 +1,111 @@
+package com.guillermonegrete.gallery.thumbnails
+
+import com.guillermonegrete.gallery.FileProvider
+import com.guillermonegrete.gallery.thumbnails.ThumbnailService.Companion.THUMBNAIL_EXT
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import net.bramp.ffmpeg.FFprobe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.awt.image.BufferedImage
+import java.io.File
+import java.io.OutputStream
+import javax.imageio.ImageIO
+
+@ExtendWith(MockKExtension::class)
+class ThumbnailServiceTest {
+
+    private lateinit var service: ThumbnailService
+
+    @MockK
+    private lateinit var fFprobe: FFprobe
+
+    @MockK
+    private lateinit var fileProvider: FileProvider
+
+    @MockK
+    private lateinit var mockThumbnail: File
+    @MockK
+    private lateinit var mockOriginalFile: File
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(ImageIO::class)
+        service = ThumbnailService(fFprobe, fileProvider)
+
+
+        val mockBaseFolder = mockk<File>()
+        val mockThumbnailsBase = mockk<File>()
+
+        // Generate the base and thumbnail folders, and the original and thumbnai file mocks
+        every { fileProvider.createFromBase(DUMMY_FOLDER) } returns mockBaseFolder
+        every { fileProvider.getFile(mockBaseFolder, DUMMY_FILE) } returns mockOriginalFile
+        every { fileProvider.getFile(mockBaseFolder, ThumbnailService.THUMBNAILS_FOLDER) } returns mockThumbnailsBase
+        every { fileProvider.getFile(mockThumbnailsBase, any()) } returns mockThumbnail
+
+        every { mockThumbnailsBase.exists() } returns true
+        every { mockOriginalFile.name } returns DUMMY_FILE // called when extracting the name without extension
+        every { mockThumbnail.exists() } returns true
+    }
+
+    @AfterEach
+    fun tearDown(){
+        unmockkStatic(ImageIO::class)
+    }
+
+    @Test
+    fun `Given existing small thumbnail, when requested, then return its byte data`(){
+        val thumbBufferImage = BufferedImage(100, 200, BufferedImage.TYPE_INT_RGB)
+        every { ImageIO.read(mockThumbnail) } returns thumbBufferImage
+        every { ImageIO.write(thumbBufferImage, any(), any<OutputStream>()) } returns true
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
+
+        // Verify bytes created from the thumbnail
+        verify { ImageIO.write(thumbBufferImage, THUMBNAIL_EXT, any<OutputStream>()) }
+    }
+
+    @Test
+    fun `Given non-existing small thumbnail, when requested, then data created`(){
+        every { mockThumbnail.exists() } returns false
+
+        // Return file larger the biggest thumbnail
+        val originalImage = BufferedImage(ThumbnailType.Large.size + 1, 200, BufferedImage.TYPE_INT_RGB)
+        every { ImageIO.read(mockOriginalFile) } returns originalImage
+        every { ImageIO.write(any(), THUMBNAIL_EXT, mockThumbnail) } returns true
+        every { ImageIO.write(any(), THUMBNAIL_EXT, any<OutputStream>()) } returns true
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
+
+        // Verify bytes created and the image was written to the thumbnail file
+        verify { ImageIO.write(any(), THUMBNAIL_EXT, mockThumbnail) }
+        verify { ImageIO.write(any(), THUMBNAIL_EXT, any<OutputStream>()) }
+    }
+
+    @Test
+    fun `Given small original image, when requested thumbnail is bigger, then return original`(){
+        every { mockThumbnail.exists() } returns false
+
+        // Return file smaller than the large thumbnail
+        val originalImage = BufferedImage(ThumbnailType.Medium.size, 200, BufferedImage.TYPE_INT_RGB)
+        every { ImageIO.read(mockOriginalFile) } returns originalImage
+        every { ImageIO.write(originalImage, any(), any<OutputStream>()) } returns true
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Large)
+
+        // Verify bytes created from the original image
+        verify { ImageIO.write(originalImage, THUMBNAIL_EXT, any<OutputStream>()) }
+    }
+
+    companion object {
+        const val DUMMY_FOLDER = "dummy"
+        const val DUMMY_FILE = "file.jpg"
+    }
+}

--- a/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
@@ -9,14 +9,21 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import net.bramp.ffmpeg.FFmpegExecutor
 import net.bramp.ffmpeg.FFprobe
+import net.bramp.ffmpeg.probe.FFmpegProbeResult
+import net.bramp.ffmpeg.probe.FFmpegStream
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.IOException
 import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Path
 import javax.imageio.ImageIO
 
 @ExtendWith(MockKExtension::class)
@@ -26,6 +33,8 @@ class ThumbnailServiceTest {
 
     @MockK
     private lateinit var fFprobe: FFprobe
+    @MockK
+    private lateinit var ffExecutor: FFmpegExecutor
 
     @MockK
     private lateinit var fileProvider: FileProvider
@@ -34,37 +43,46 @@ class ThumbnailServiceTest {
     private lateinit var mockThumbnail: File
     @MockK
     private lateinit var mockOriginalFile: File
+    @MockK
+    private lateinit var mockThumbnailsBase: File
 
     @BeforeEach
     fun setup() {
         mockkStatic(ImageIO::class)
-        service = ThumbnailService(fFprobe, fileProvider)
+        mockkStatic(Files::class)
+        service = ThumbnailService(fFprobe, ffExecutor, fileProvider)
 
 
         val mockBaseFolder = mockk<File>()
-        val mockThumbnailsBase = mockk<File>()
 
         // Generate the base and thumbnail folders, and the original and thumbnai file mocks
         every { fileProvider.createFromBase(DUMMY_FOLDER) } returns mockBaseFolder
         every { fileProvider.getFile(mockBaseFolder, DUMMY_FILE) } returns mockOriginalFile
         every { fileProvider.getFile(mockBaseFolder, ThumbnailService.THUMBNAILS_FOLDER) } returns mockThumbnailsBase
-        every { fileProvider.getFile(mockThumbnailsBase, any()) } returns mockThumbnail
+        val thumbnailFilename = ThumbnailType.Small.filename(DUMMY_FILE_NO_EXT)
+        every { fileProvider.getFile(mockThumbnailsBase, thumbnailFilename) } returns mockThumbnail
 
         every { mockThumbnailsBase.exists() } returns true
         every { mockOriginalFile.name } returns DUMMY_FILE // called when extracting the name without extension
         every { mockThumbnail.exists() } returns true
+
+        every { mockOriginalFile.absolutePath } returns ""
+        every { mockThumbnail.absolutePath } returns "thumbnail.webp"
+
+        every { ffExecutor.createJob(any()) } returns mockk(relaxed = true)
     }
 
     @AfterEach
     fun tearDown(){
         unmockkStatic(ImageIO::class)
+        unmockkStatic(Files::class)
     }
+
+    // region Image tests
 
     @Test
     fun `Given existing small thumbnail, when requested, then return its byte data`(){
-        val thumbBufferImage = BufferedImage(100, 200, BufferedImage.TYPE_INT_RGB)
-        every { ImageIO.read(mockThumbnail) } returns thumbBufferImage
-        every { ImageIO.write(thumbBufferImage, any(), any<OutputStream>()) } returns true
+        val thumbBufferImage = setupBufferedImage(mockThumbnail, 100)
 
         service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
 
@@ -76,8 +94,8 @@ class ThumbnailServiceTest {
     fun `Given non-existing small thumbnail, when requested, then data created`(){
         every { mockThumbnail.exists() } returns false
 
-        // Return file larger the biggest thumbnail
-        val originalImage = BufferedImage(ThumbnailType.Large.size + 1, 200, BufferedImage.TYPE_INT_RGB)
+        // Return file larger than the requested thumbnail
+        val originalImage = BufferedImage(ThumbnailType.Small.size + 1, 200, BufferedImage.TYPE_INT_RGB)
         every { ImageIO.read(mockOriginalFile) } returns originalImage
         every { ImageIO.write(any(), THUMBNAIL_EXT, mockThumbnail) } returns true
         every { ImageIO.write(any(), THUMBNAIL_EXT, any<OutputStream>()) } returns true
@@ -93,19 +111,114 @@ class ThumbnailServiceTest {
     fun `Given small original image, when requested thumbnail is bigger, then return original`(){
         every { mockThumbnail.exists() } returns false
 
-        // Return file smaller than the large thumbnail
-        val originalImage = BufferedImage(ThumbnailType.Medium.size, 200, BufferedImage.TYPE_INT_RGB)
-        every { ImageIO.read(mockOriginalFile) } returns originalImage
-        every { ImageIO.write(originalImage, any(), any<OutputStream>()) } returns true
+        // Return file smaller than the requested thumbnail
+        val originalImage = setupBufferedImage(mockOriginalFile,ThumbnailType.Small.size - 1)
 
-        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Large)
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
 
         // Verify bytes created from the original image
         verify { ImageIO.write(originalImage, THUMBNAIL_EXT, any<OutputStream>()) }
     }
 
+    @Test
+    fun `Given non-existing original image thumbnail, when requested, then error`(){
+        createOriginalThumbnailMock(exists = false)
+
+        every { mockOriginalFile.toPath() } returns Path.of("")
+        every { Files.probeContentType(Path.of("")) } returns "image/jpeg"
+
+        assertThrows(IOException::class.java) {
+            service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Original)
+        }
+        verify(exactly = 0) { ffExecutor.createJob(any()) }
+    }
+
+    // endregion
+
+    // region Video tests
+
+    @Test
+    fun `Given non-existing small video thumbnail, when requested, then data created`(){
+        val videoWidth = ThumbnailType.ExtraLarge.size + 1
+        setupForVideo(videoWidth)
+
+        val bufferedThumbnail = setupBufferedImage(mockThumbnail, ThumbnailType.Small.size)
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
+
+        // Verify bytes created from the thumbnail
+        verify { ImageIO.write(bufferedThumbnail, THUMBNAIL_EXT, any<OutputStream>()) }
+        verify { ffExecutor.createJob(any()) }
+    }
+
+    @Test
+    fun `Given small original video, when requested thumbnail is bigger, then return original`(){
+        val videoWidth = ThumbnailType.Small.size - 1
+        setupForVideo(videoWidth)
+
+        val mockSourceThumbnail = createOriginalThumbnailMock()
+        val bufferedThumbnail = setupBufferedImage(mockSourceThumbnail, videoWidth)
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Small)
+
+        // Verify bytes created from the original size thumbnail
+        verify { ImageIO.write(bufferedThumbnail, THUMBNAIL_EXT, any<OutputStream>()) }
+        verify(exactly = 0) { ffExecutor.createJob(any()) }
+    }
+
+    @Test
+    fun `Given non-existing original video thumbnail, when requested, then data created`(){
+        every { mockOriginalFile.toPath() } returns Path.of("")
+        every { Files.probeContentType(Path.of("")) } returns "video/mp4"
+
+        val mockSourceThumbnail = createOriginalThumbnailMock(exists = false)
+        val bufferedThumbnail = setupBufferedImage(mockSourceThumbnail, 200)
+
+        service.generateThumbnail(DUMMY_FOLDER, DUMMY_FILE, ThumbnailType.Original)
+
+        // Verify bytes created from the thumbnail
+        verify { ImageIO.write(bufferedThumbnail, THUMBNAIL_EXT, any<OutputStream>()) }
+        verify { ffExecutor.createJob(any()) }
+    }
+
+    // endregion
+
+    /**
+     * Setups the buffered image that will be used to generate the output ByteArray.
+     */
+    private fun setupBufferedImage(file: File, width: Int): BufferedImage {
+        val bufferedThumbnail = BufferedImage(width, 200, BufferedImage.TYPE_INT_RGB)
+        every { ImageIO.read(file) } returns bufferedThumbnail
+        every { ImageIO.write(bufferedThumbnail, THUMBNAIL_EXT, any<OutputStream>()) } returns true
+        return bufferedThumbnail
+    }
+
+    private fun createOriginalThumbnailMock(exists: Boolean = true): File {
+        val mockSourceThumbnail = mockk<File>()
+        every { mockSourceThumbnail.exists() } returns exists
+        val thumbnailFilename = ThumbnailType.Original.filename(DUMMY_FILE_NO_EXT)
+        every { mockSourceThumbnail.absolutePath } returns thumbnailFilename
+        every { fileProvider.getFile(mockThumbnailsBase, thumbnailFilename) } returns mockSourceThumbnail
+
+        return mockSourceThumbnail
+    }
+
+    private fun setupForVideo(videoWidth: Int) {
+        every { mockThumbnail.exists() } returns false
+
+        every { ImageIO.read(mockOriginalFile) } returns null
+        val stream = FFmpegStream()
+        stream.codec_type = FFmpegStream.CodecType.VIDEO
+        stream.width = videoWidth
+
+        val probeMock = mockk<FFmpegProbeResult>()
+        every { probeMock.getStreams() } returns listOf(stream)
+        every { fFprobe.probe("") } returns probeMock
+    }
+
     companion object {
         const val DUMMY_FOLDER = "dummy"
         const val DUMMY_FILE = "file.jpg"
+        const val DUMMY_FILE_NO_EXT = "file"
     }
 }


### PR DESCRIPTION
Closes #40.

Differences from the original issue:

- The thumbnails are not generated when processing the folders, but on demand when the URL for the specific thumbnail is called.
- There are 5 different initial sizes for thumbnail (small, medium, large, extra large, and original)
- The original size thumbnail is only available for videos. For images, it's better to request the image directly.
- The thumbnails are in `webp` format.
- The thumbnails are not created if the original image is smaller than the requested size. Instead, the original size is returned.
- Created an endpoint that returns info about the files; in this case, it returns the available thumbnail sizes.
- The filename is now returned in the file payload.
- Upgraded Spring version to 3.5.7, which includes Jackson 2.19.
- A thumbnail folder is created for every processed subfolder.