### PR TITLE
Pr/thumbnails improvements

### DIFF
--- a/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/GalleryApplication.kt
@@ -8,7 +8,9 @@ import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableAsync
 
+@EnableAsync
 @SpringBootApplication
 class GalleryApplication{
     @Value("\${final.path}")

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/Folder.kt
@@ -5,6 +5,7 @@ import com.guillermonegrete.gallery.repository.FolderDto
 data class Folder(
     val name:String,
     val coverUrl: String,
+    val coverFilename: String,
     val count: Int,
     val id: Long,
 )
@@ -16,9 +17,12 @@ data class PagedFolderResponse(
 
 fun MediaFolder.toDto(fileName: String, ipAddress: String): Folder {
     val coverUrl = "http://$ipAddress/images/$name/$fileName"
-    return Folder(name, coverUrl, files.size, id)
+    return Folder(name, coverUrl, fileName, files.size, id)
 }
 
-fun MediaFolder.toDto(ipAddress: String) = Folder(name, "http://$ipAddress/images/$name/${coverFile?.filename ?: files.firstOrNull()?.filename}", files.size, id)
+fun MediaFolder.toDto(ipAddress: String): Folder {
+    val filename = coverFile?.filename ?: files.firstOrNull()?.filename ?: ""
+    return Folder(name, "http://$ipAddress/images/$name/$filename", filename, files.size, id)
+}
 
-fun FolderDto.toFolder(ipAddress: String) = Folder(name, "http://$ipAddress/images/$name/$coverUrl", count, id)
+fun FolderDto.toFolder(ipAddress: String) = Folder(name, "http://$ipAddress/images/$name/$coverUrl", coverUrl ?: "", count, id)

--- a/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/data/files/FileMapper.kt
@@ -30,7 +30,7 @@ class FileMapper {
 
     fun toSingleDto(e: MediaFile, host: String): FileDTO {
         val url = "http://$host/images/${e.folder.name}/${e.filename}"
-        val folder = Folder(e.folder.name, "", e.folder.files.size, e.folder.id)
+        val folder = Folder(e.folder.name, "", "", e.folder.files.size, e.folder.id)
         val base = BaseFile(url, e.filename, e.width, e.height, e.creationDate, e.lastModified, e.tags.toBaseDto(), e.id)
         return when(e){
             is VideoEntity -> SingleVideoFile(folder, VideoFileDTO(e.duration, base))

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -6,12 +6,14 @@ import net.bramp.ffmpeg.FFmpegExecutor
 import net.bramp.ffmpeg.FFprobe
 import net.bramp.ffmpeg.builder.FFmpegBuilder
 import net.bramp.ffmpeg.probe.FFmpegStream
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
+import java.util.concurrent.CompletableFuture
 import javax.imageio.ImageIO
 
 @Service
@@ -21,7 +23,8 @@ class ThumbnailService(
     private val fileProvider: FileProvider,
 ) {
 
-    fun generateThumbnail(folder: String, filename: String, type: ThumbnailType): ByteArray {
+    @Async
+    fun generateThumbnail(folder: String, filename: String, type: ThumbnailType): CompletableFuture<ByteArray> {
 
         val baseFolder = fileProvider.createFromBase(folder)
         val originalFile = fileProvider.getFile(baseFolder, filename)
@@ -35,14 +38,14 @@ class ThumbnailService(
             val thumbnail = ImageIO.read(newFile)
             val baos = ByteArrayOutputStream()
             ImageIO.write(thumbnail, THUMBNAIL_EXT, baos)
-            return baos.toByteArray()
+            return CompletableFuture.completedFuture(baos.toByteArray())
         }
 
         // Return original size thumbnail (for videos only)
         if (type == ThumbnailType.Original) {
             val baos = ByteArrayOutputStream()
             ImageIO.write(generateVideoThumbnail(originalFile, newFile), THUMBNAIL_EXT, baos)
-            return baos.toByteArray()
+            return CompletableFuture.completedFuture(baos.toByteArray())
         }
 
         // Otherwise generate new thumbnail
@@ -65,7 +68,7 @@ class ThumbnailService(
         // Return byte data
         val baos = ByteArrayOutputStream()
         ImageIO.write(img, THUMBNAIL_EXT, baos)
-        return baos.toByteArray()
+        return CompletableFuture.completedFuture(baos.toByteArray())
     }
 
     private fun generateVideoThumbnail(

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailService.kt
@@ -32,7 +32,7 @@ class ThumbnailService(
         // Check if thumbnail already exists
         val thumbnailsFolder = fileProvider.getFile(baseFolder, THUMBNAILS_FOLDER)
         if (!thumbnailsFolder.exists()) thumbnailsFolder.mkdir()
-        val newFilename = type.filename(originalFile.nameWithoutExtension)
+        val newFilename = type.filename(originalFile.name)
         val newFile = fileProvider.getFile(thumbnailsFolder, newFilename)
         if (newFile.exists()) {
             val thumbnail = ImageIO.read(newFile)
@@ -83,7 +83,7 @@ class ThumbnailService(
 
         var targetFile = newFile
         if (!originalIsBigger) {
-            targetFile = fileProvider.getFile(thumbnailsFolder, ThumbnailType.Original.filename(originalFile.nameWithoutExtension))
+            targetFile = fileProvider.getFile(thumbnailsFolder, ThumbnailType.Original.filename(originalFile.name))
             if (targetFile.exists()) return ImageIO.read(targetFile)
         }
 
@@ -133,4 +133,4 @@ enum class ThumbnailType(val size: Int) {
     }
 }
 
-fun ThumbnailType.filename(nameNoExt: String) = "$nameNoExt-${name.lowercase()}.$THUMBNAIL_EXT"
+fun ThumbnailType.filename(originalFilename: String) = "$originalFilename.${name.lowercase()}.$THUMBNAIL_EXT"

--- a/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
+++ b/src/main/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailsController.kt
@@ -1,12 +1,11 @@
 package com.guillermonegrete.gallery.thumbnails
 
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.CompletableFuture
 
 @RestController
 class ThumbnailsController(private val thumbnailService: ThumbnailService) {
@@ -17,12 +16,10 @@ class ThumbnailsController(private val thumbnailService: ThumbnailService) {
         @PathVariable subFolder: String,
         @PathVariable filename: String,
         @RequestParam("size") size: String?
-    ): ResponseEntity<ByteArray> {
+    ): CompletableFuture<ByteArray> {
         val type = if (size == null) ThumbnailType.Small else ThumbnailType.getThumbnailType(size) ?: ThumbnailType.Small
 
-        return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType("image/webp"))
-            .body(thumbnailService.generateThumbnail(subFolder, filename, type))
+        return thumbnailService.generateThumbnail(subFolder, filename, type)
     }
 }
 

--- a/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/FoldersControllerTest.kt
@@ -69,14 +69,15 @@ class FoldersControllerTest(
     @Throws(Exception::class)
     @Test
     fun `Folders endpoint returns paged response model`(){
-        val pageable = PageRequest.of(0, 20)
-        val content = List(21) { MediaFolder("name$it", listOf(MediaFile("image.jpg")), id = 100L + it) }
+        val filename = "image.jpg"
+        val content = List(21) { MediaFolder("name$it", listOf(MediaFile(filename)), id = 100L + it) }
         val subList = content.subList(0, 20)
+        val pageable = PageRequest.of(0, 20)
         every { mediaFolderRepository.findAll(pageable) } returns PageImpl(subList, pageable, content.size.toLong())
 
         val expected = PagedFolderResponse(
             path,
-            SimplePage(subList.map { Folder(it.name, "http://$ipAddress/images/${it.name}/image.jpg", 1, it.id) },
+            SimplePage(subList.map { Folder(it.name, "http://$ipAddress/images/${it.name}/$filename", filename, 1, it.id) },
             2, content.size),
         )
         val result = mockMvc.perform(get("/folders")).andDo(print())

--- a/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/guillermonegrete/gallery/thumbnails/ThumbnailServiceTest.kt
@@ -59,7 +59,7 @@ class ThumbnailServiceTest {
         every { fileProvider.createFromBase(DUMMY_FOLDER) } returns mockBaseFolder
         every { fileProvider.getFile(mockBaseFolder, DUMMY_FILE) } returns mockOriginalFile
         every { fileProvider.getFile(mockBaseFolder, THUMBNAILS_FOLDER) } returns mockThumbnailsBase
-        val thumbnailFilename = ThumbnailType.Small.filename(DUMMY_FILE_NO_EXT)
+        val thumbnailFilename = ThumbnailType.Small.filename(DUMMY_FILE)
         every { fileProvider.getFile(mockThumbnailsBase, thumbnailFilename) } returns mockThumbnail
 
         every { mockThumbnailsBase.exists() } returns true
@@ -67,7 +67,7 @@ class ThumbnailServiceTest {
         every { mockThumbnail.exists() } returns true
 
         every { mockOriginalFile.absolutePath } returns ""
-        every { mockThumbnail.absolutePath } returns "thumbnail.webp"
+        every { mockThumbnail.absolutePath } returns "/root/$thumbnailFilename"
 
         every { ffExecutor.createJob(any()) } returns mockk(relaxed = true)
     }
@@ -196,7 +196,7 @@ class ThumbnailServiceTest {
     private fun createOriginalThumbnailMock(exists: Boolean = true): File {
         val mockSourceThumbnail = mockk<File>()
         every { mockSourceThumbnail.exists() } returns exists
-        val thumbnailFilename = ThumbnailType.Original.filename(DUMMY_FILE_NO_EXT)
+        val thumbnailFilename = ThumbnailType.Original.filename(DUMMY_FILE)
         every { mockSourceThumbnail.absolutePath } returns thumbnailFilename
         every { fileProvider.getFile(mockThumbnailsBase, thumbnailFilename) } returns mockSourceThumbnail
 


### PR DESCRIPTION
The fixes and improvements include:

- The thumbnail controller and service are now async.
- The filename for the cover URL is now returned in the folder payload.
- Fixed using the wrong thumbnail when another file had the same name but a different extension.